### PR TITLE
Only reset pointer if it is freed.

### DIFF
--- a/libpng/pngwutil.c
+++ b/libpng/pngwutil.c
@@ -350,8 +350,10 @@ png_write_compressed_data_out(png_structp png_ptr, compression_state *comp)
       comp->output_ptr[i]=NULL;
    }
    if (comp->max_output_ptr != 0)
+   {
       png_free(png_ptr, comp->output_ptr);
       comp->output_ptr=NULL;
+   }
    /* write anything left in zbuf */
    if (png_ptr->zstream.avail_out < (png_uint_32)png_ptr->zbuf_size)
       png_write_chunk_data(png_ptr, png_ptr->zbuf,


### PR DESCRIPTION
Signed-off-by: Andrea Odetti <mariofutire@gmail.com>

Not 100% sure it is a bug, but very suspicious.
If it is not a bug, indentation should be fixed instead.
