### PR TITLE
Fix FSF address in headers and license file

### DIFF
--- a/GUI/xephem/indiapi.h
+++ b/GUI/xephem/indiapi.h
@@ -17,7 +17,7 @@
 
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #endif
 


### PR DESCRIPTION
Some headers and the liblilxml license file still report the outdated Free Software Foundation address.