### PR TITLE
fix(libastro): fix using wrong macro in obj_description(Obj *op)

### DIFF
--- a/libastro/misc.c
+++ b/libastro/misc.c
@@ -123,7 +123,7 @@ obj_description (Obj *op)
 	case BINARYSTAR:
 	    if (op->f_class) {
 		int i;
-		for (i = 0; i < NFCM; i++)
+		for (i = 0; i < NBCM; i++)
 		    if (binary_class_map[i].classcode == op->f_class)
 			return (binary_class_map[i].desc);
 	    }


### PR DESCRIPTION
I think that wrong macro may being used in for loop