### PR TITLE
Prevent buffer overflows in libastro

### DIFF
--- a/libastro/constel.c
+++ b/libastro/constel.c
@@ -1673,7 +1673,7 @@ cns_loadfigs (FILE *fp, char *msg)
 		continue;
 
 	    /* ok, line looks interesting, look more carefully */
-	    if (sscanf (lp, "%d %s %s", &code, rastr, decstr) == 3) {
+	    if (sscanf (lp, "%d %63s %63s", &code, rastr, decstr) == 3) {
 		/* looks like a drawing line */
 		double ra, dec;
 

--- a/libastro/magdecl.c
+++ b/libastro/magdecl.c
@@ -148,7 +148,7 @@ GEOMAG:
       c[0][0] = 0.0;
       cd[0][0] = 0.0;
       fgets(c_str, 80, wmmdat);
-      sscanf(c_str,"%f%s",&epoc,model);
+      sscanf(c_str,"%f%19s",&epoc,model);
 S3:
       fgets(c_str, 80, wmmdat);
 /* CHECK FOR LAST LINE IN FILE */

--- a/libastro/misc.c
+++ b/libastro/misc.c
@@ -140,7 +140,7 @@ obj_description (Obj *op)
 		return ("Planet");
 	    if (!biop)
 		getBuiltInObjs (&biop);
-	    sprintf (nsstr, "Moon of %s", biop[op->pl_code].o_name);
+	    sprintf (nsstr, "Moon of %7s", biop[op->pl_code].o_name);
 	    return (nsstr);
 	    }
 	case EARTHSAT:


### PR DESCRIPTION
Fix potential buffer overflows caused by:
- Unbounded %s format specifier with sscanf reading ill-formed external files (.csf & .cof).
- Unbounded %s format specifier with sprintf  writing planet name in obj_description.

For the second one, it may be formally better using:
```
#define OBJ_DESC_STRINGIFY_NAME(MACRO) #MACRO
#define OBJ_DESC_STRINGIFY_VAL(MACRO) OBJ_DESC_STRINGIFY_NAME(MACRO)
...
        case PLANET: {
            const char fmt[] = "Moon of %" OBJ_DESC_STRINGIFY_VAL(MAXNM) "s";
            static char nsstr[8 + MAXNM];
            ...
            sprintf (nsstr, fmt, biop[op->pl_code].o_name);
``` 