### PR TITLE
sunmenu: Define _GNU_SOURCE, so that <time.h> declares strptime

### DIFF
--- a/GUI/xephem/sunmenu.c
+++ b/GUI/xephem/sunmenu.c
@@ -1,6 +1,9 @@
 /* code to manage the sun display 
  */
 
+/* For the declaration of strptime in <time.h>. */
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>


### PR DESCRIPTION
The function isan X/Open extension that is not available by default in the glibc headers.  Currently, this works because compilers support implicit function declarations, but future versions are likely to disable by them default, to improve type safety.

**Note:** I'm not entirely sure if this is the right way to do this. Maybe `-D_GNU_SOURCE` should be included in the compiler flags globally.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
