### PR TITLE
Inclusion of desktop and metadata files for the GUI application

### DIFF
--- a/GUI/xephem/Makefile
+++ b/GUI/xephem/Makefile
@@ -1,4 +1,4 @@
-# Sample Makefile for xephem v3.7
+# Sample Makefile for xephem v4.1.0
 
 # Sample compile and link flags for a few systems. Find your system or similar
 # and uncomment as required. The default is for linux or Mac OS X systems.
@@ -42,6 +42,13 @@ CFLAGS = $(LIBINC) $(CLDFLAGS) -O2 -Wall -I$(MOTIFI) $(PLATI)
 LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) $(PLATL)
 XLIBS = -lXm -lXt -lXext -lXmu -lX11
 LIBS = $(XLIBS) $(LIBLIB) -lm -lssl
+
+# Variables installation for Linux
+prefix := /usr/local
+bindir = $(prefix)/bin
+datadir = $(prefix)/share
+mandir = $(datadir)/man
+export datadir
 
 # static linking on Apple using X11 libs from ports
 # CC = gcc
@@ -192,24 +199,43 @@ OBJS =			\
 	xephem.o	\
 	xmisc.o
 
-all: libs xephem xephem.1
+all: xephem xephem.1
 
-xephem: $(INCS) $(OBJS)
+xephem: libs $(INCS) $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
 xephem.1: xephem.man
-	nroff -man $? > $@
+	cp $? $@
 
 libs:
-	cd ../../libastro; make
-	cd ../../libip; make
-	cd ../../libjpegd; make
-	cd ../../liblilxml; make
-	cd ../../libpng; make
-	cd ../../libz; make
+	$(MAKE) -C ../../libastro
+	$(MAKE) -C ../../libip
+	$(MAKE) -C ../../libjpegd
+	$(MAKE) -C ../../liblilxml
+	$(MAKE) -C ../../libpng
+	$(MAKE) -C ../../libz
 
 clean:
 	rm -fr *.o ../../lib*/*.[ao]
 
 clobber: clean
 	rm -fr xephem xephem.1
+
+# Installation
+install: install-binary install-man install-data install-desktopfiles
+
+install-binary:
+	install -Dm 755 xephem -t $(DESTDIR)$(bindir)
+
+install-man:
+	install -Dm 644 xephem.1 -t $(DESTDIR)$(mandir)/man1
+
+install-data:
+	install -dm 755 $(DESTDIR)$(datadir)/xephem
+	@for d in auxil catalogs fifos fits gallery help lo; do \
+	  echo "cp -R $$d $(DESTDIR)$(datadir)/xephem"; \
+	  cp -R $$d $(DESTDIR)$(datadir)/xephem; \
+	done
+
+install-desktopfiles:
+	$(MAKE) -C ../../desktopfiles DESTDIR=$(DESTDIR) install

--- a/GUI/xephem/datamenu.c
+++ b/GUI/xephem/datamenu.c
@@ -109,7 +109,7 @@ static ColHdr col[] = {
     {MISC_COL,	"SnLght",  "Light travel time from Sun"},
     {MISC_COL,	"Uranom",  "Volume and page number in Uranometria"},
     {MISC_COL,	"Uran2k",  "Volume and page number in Uranometria 2000"},
-    {MISC_COL,	"MillSA",  "Volume and page number in Millenium Star Atlas"},
+    {MISC_COL,	"MillSA",  "Volume and page number in Millennium Star Atlas"},
 
     {RISET_COL,	"RisTm",   "Rise time, today"},
     {RISET_COL,	"RisAz",   "Rise azimuth, today"},

--- a/GUI/xephem/help/xephem.html
+++ b/GUI/xephem/help/xephem.html
@@ -1753,7 +1753,7 @@ number of object's location in the new Uranometria 2000 edition.</li>
 </ul>
 <ul>
   <li><span style="font-weight: bold;">MillSA</span> Volume and Page
-number of object's location in the Millenium Star Atlas, published
+number of object's location in the Millennium Star Atlas, published
 by Sky Publishing Corp.</li>
 </ul>
 Section two controls information related to rising, transitting, and

--- a/GUI/xephem/imregmenu.c
+++ b/GUI/xephem/imregmenu.c
@@ -229,7 +229,7 @@ ir_create()
 	s2_w = XmCreateToggleButton (irshell_w, "S1TB", args, n);
 	XtAddCallback (s2_w, XmNvalueChangedCallback, reg_cb, NULL);
 	set_xmstring (s2_w, XmNlabelString,
-		    "Image to be registed is loaded, now click same 2 stars");
+		    "Image to be registered is loaded, now click same 2 stars");
 	XtManageChild (s2_w);
 
 	/* labels for second set of reference stars */

--- a/GUI/xephem/skylist.c
+++ b/GUI/xephem/skylist.c
@@ -98,7 +98,7 @@ typedef struct {
     char *desc;			/* description */
     char ura[ATLASLEN];		/* Uranometria page number */
     char u2k[ATLASLEN];		/* Uranometria 200 page number */
-    char msa[ATLASLEN];		/* Millenium Star Atlas page number */
+    char msa[ATLASLEN];		/* Millennium Star Atlas page number */
 } ObjInfo;
 
 /* handy "no rise/set" test */
@@ -139,7 +139,7 @@ static SortInfo sinfo[] = {
 
     {"Urano",  "Uranometria",      sort_ura},
     {"Uran2k", "Uranom 2000",      sort_u2k},
-    {"MillSA", "Millenium",        sort_msa},
+    {"MillSA", "Millennium",       sort_msa},
     {"RisTm",  "Rise time",        sort_risetm},
     {"RisAz",  "Rise azimuth",     sort_riseaz},
     {"TrnTm",  "Transit time",     sort_trantm},

--- a/desktopfiles/Makefile
+++ b/desktopfiles/Makefile
@@ -1,0 +1,38 @@
+# Makefile for manage desktop files
+# Requires utility 'convert' of the package ImageMagick.
+
+CONVERT = convert
+
+SRCPNGICON = ../GUI/xephem/XEphem.png
+PNGICONS = \
+	32x32/apps/xephem.png \
+	48x48/apps/xephem.png \
+	64x64/apps/xephem.png \
+	128x128/apps/xephem.png
+DESKTOPFILE = xephem.desktop
+METAINFOFILE = xephem.metainfo.xml
+
+iconsdir = $(DESTDIR)$(datadir)/icons/hicolor
+applicationsdir = $(DESTDIR)$(datadir)/applications
+metainfodir = $(DESTDIR)$(datadir)/metainfo
+
+
+all:
+
+install: install-icons install-desktopfile install-metainfo
+
+install-icons: $(PNGICONS)
+
+$(PNGICONS): $(SRCPNGICON)
+	@d=$(iconsdir)/$(shell dirname $@); \
+	s=$(shell echo $@ | sed -e 's/[a-z]*\([0-9]*\).*/\1/'); \
+	echo "install -m 755 -d $$d"; \
+	install -m 755 -d $$d; \
+	echo "convert -geometry $${s}x$${s} -depth 8 -background none $< $(iconsdir)/$@"; \
+	$(CONVERT) -geometry $${s}x$${s} -depth 8 -background none $< $(iconsdir)/$@
+
+install-desktopfile:
+	install -Dm 644 $(DESKTOPFILE) -t $(applicationsdir)
+
+install-metainfo:
+	install -Dm 644 $(METAINFOFILE) -t $(metainfodir)

--- a/desktopfiles/xephem.desktop
+++ b/desktopfiles/xephem.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=XEphem
+GenericName=X Window Ephemeris
+GenericName[es]=Ventana X de Efemérides
+Comment=Interactive astronomical ephemeris software
+Comment[es]=Software Interactivo de efemérides astrónomicas
+Exec=xephem
+Icon=xephem
+Terminal=false
+Categories=Science;Astronomy;Motif;
+Keywords=Astronomy;

--- a/desktopfiles/xephem.metainfo.xml
+++ b/desktopfiles/xephem.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Miguel Molina <mmolina.unphysics@gmail.com> -->
+<component type="desktop-application">
+  <id>xephem.desktop</id>
+  <name>XEphem</name>
+  <name xml:lang="es">XEphem</name>
+  <summary>Interactive astronomical ephemeris software</summary>
+  <summary xml:lang="es">Software interactivo de efemérides astronómicas</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>
+      <ul>
+	<li><em>XEphem</em> is an interactive astronomy program for all UNIX platforms, written and maintained by _Elwood Downey_ over more than thirty years 1990–2021 and now generously released under the MIT License.</li>
+	<li><em>XEphem</em> can compute information on demand or time can be set to increment automatically. In this way a series of computations and movies can be generated.</li>
+      </ul>
+    </p>
+    <p xml:lang="es">
+      <ul>
+	<li><em>XEphem</em> es un programa de astronomía interactivo para todas las plataformas UNIX, escrito y mantenido por _Elwood Downey_ durante más de treinta años entre 1990 y 2021 y ahora publicado generosamente bajo la licencia MIT.</li>
+	<li><em>XEphem</em> puede calcular información bajo demanda o se puede configurar automáticamente en el tiempo. De esta forma se pueden generar una serie de cálculos y animaciones.</li>
+      </ul>	
+    </p>
+  </description>
+  <launchable type="desktop-id">xephem.desktop</launchable>
+  <url type="homepage">https://xephem.github.io/XEphem/Site/xephem.html</url>
+  <url type="help">https://xephem.github.io/XEphem/Site/help/xephem.html</url>
+  <update_contact>xephem@ClearSkyInstitute.com</update_contact>
+  <developer_name>Elwood Charles Downey</developer_name>
+  <releases>
+    <release date="2021-09-13" version="4.1.0"/>
+  </releases>
+  <provides>
+    <binary>xephem</binary>
+  </provides>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/XEphem/XEphem/main/GUI/xephem/help/png/sky-view.png</image>
+      <caption>Highly configurable interactive Sky View.</caption>
+      <caption xml:lang="es">Vista del cielo interactivo altamente configurable.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/XEphem/XEphem/main/GUI/xephem/help/png/solsys.png</image>
+      <caption>3D projection and true stereo views of the solar system, perfect for visualizing comet paths.</caption>
+      <caption xml:lang="es">Proyecciones 3D y vistas estereográficas reales del sistema solar, perfectas para visualizar trayectorias de cometas.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/XEphem/XEphem/main/GUI/xephem/help/png/sun-view.png</image>
+      <caption>Near real-time Solar images from the SOHO spacecraft.</caption>
+      <caption xml:lang="es">Imágenes solares en tiempo real desed la nave espacial SOHO.</caption>
+    </screenshot>
+  </screenshots>
+</component>


### PR DESCRIPTION
This PR is a contribution which adds the desktop and [AppStream metadata](https://www.freedesktop.org/software/appstream/docs/chap-AppStream-About.html) files for XEphem and its integration with the source code.

AppStream metadata provides information about the application in the software centers of some Linux distributions (for example, in GNOME software included in Ubuntu), showing for the end-user a specific description and screenshots of the application, with the opportunity to translate this information into different languages. Linux distributions such as Debian and Fedora suggest in their packaging practices to include *.desktop and *.metainfo files for GUI applications.

The attached screenshot shows the presentation of XEphem in the GNOME software of my Ubuntu 18.04.

![Software_Ubuntu](https://user-images.githubusercontent.com/8185531/221333907-c5d3946b-8cac-4ba0-a213-270754fcfe4f.png)
