### PR TITLE
Fixed for working with Ubuntu 22.04 in docker containers; cd Containe…

### DIFF
--- a/Containers/docker-ubuntu-22.04/Dockerfile
+++ b/Containers/docker-ubuntu-22.04/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:22.04
+
+# Install everything XEphem needs to compile.
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update
+RUN apt upgrade -y -y
+RUN apt install -y -y apt-file
+RUN apt-file update
+RUN apt install -y -y \
+    build-essential \
+    groff-base \
+    libmotif-dev \
+    libssl-dev \
+    libxext-dev \
+    libxmu-dev \
+    libxt-dev
+
+# Remove the Linux empty /srv directory so it does not interrupt tab
+# completion of /src, where we put the XEphem source tree.
+
+RUN rmdir /srv
+
+# Set up /root as our home directory, with a useful bash history and an
+# “.xephem” symlink that shows XEphem where to find its support files.
+
+ENV HOME /root
+RUN ln -s /src/GUI/xephem/auxil /root/.xephem
+RUN echo 'make -C /src/GUI/xephem && (cd /src/GUI/xephem; ./xephem)' \
+    > /root/.bash_history
+
+# Start the user in the /src directory.
+
+WORKDIR /src/GUI/xephem
+CMD /bin/bash

--- a/Containers/docker-ubuntu-22.04/README.md
+++ b/Containers/docker-ubuntu-22.04/README.md
@@ -1,0 +1,21 @@
+
+# XEphem Docker container
+
+This directory offers a `Dockerfile` plus a small shell script `run`.
+Run the shell script to build and launch a Ubuntu 14.04 container with
+all the libraries XEphem needs:
+
+    ./container/run
+
+Then, at the container’s prompt (which looks like `root@...:/src#`),
+you can build XEphem with:
+
+    make -C /src/GUI/xephem
+
+And run it with:
+
+    /src/GUI/xephem/xephem
+
+If you press up-arrow at the bash prompt right after the container
+launches, you will find this pair of commands already in the shell
+history so you can simply press Enter to run them.

--- a/Containers/docker-ubuntu-22.04/run
+++ b/Containers/docker-ubuntu-22.04/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-NAME=xephem-ubuntu-21.04
+NAME=xephem-ubuntu-22.04
 
 if [ ! -f /usr/bin/docker ]
 then

--- a/Containers/docker-ubuntu-22.04/run
+++ b/Containers/docker-ubuntu-22.04/run
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -ex
+NAME=xephem-ubuntu-21.04
+
+if [ ! -f /usr/bin/docker ]
+then
+    echo 'Error: please "apt install docker.io"' >&2
+    exit 2
+fi
+
+# Change directory to the directory with this script and its Dockerfile.
+
+cd "$(dirname $0)"
+
+# Build the Docker image from the instructions in the Dockerfile.
+# Name the resulting image "xephem".
+
+if [ "$1" = "--no-cache" ]
+then
+    NO_CACHE=--no-cache
+    shift
+else
+    NO_CACHE=
+fi
+docker build -t $NAME . 1>&2 $NO_CACHE
+
+# Run the "xephem" image, exposing several files from the host system
+# that together should let XEphem run and connect to X Windows:
+#
+# 1. This XEphem source tree, which gets mounted at "/src".
+# 2. The collection of X11 sockets in /tmp.
+# 3. Our X session's private authority file.
+
+exec docker run -ti \
+     --net=host \
+     -e DISPLAY=$DISPLAY \
+     -v ${PWD}/../..:/src \
+     -v /tmp/.X11-unix:/tmp/.X11-unix \
+     -v ${XAUTHORITY}:/root/.Xauthority \
+     $NAME \
+     "$@"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ when sitting at the repository root are:
     $ ./Containers/docker-ubuntu-14.04/run
     $ ./Containers/docker-ubuntu-20.04/run
     $ ./Containers/docker-ubuntu-21.04/run
+    $ ./Containers/docker-ubuntu-22.04/run
 
 Once one of the containers has launched, use the shell command history:
 press up-arrow to ask for the previous command — it will be the correct


### PR DESCRIPTION
Fixed for working with Ubuntu 22.04 in docker containers; 

  cd Containers/;
  cp -r docker-ubuntu-2{1,2}.04/
  perl -pi -e 's/21.04/22.04/g' docker-ubunut-22.04/Dockerfile; 

Voila, works to run docker container on Ubuntu 22.04;