### PR TITLE
New revision to the inclusion of desktop and metadata files for the GUI application

### DIFF
--- a/GUI/xephem/Makefile
+++ b/GUI/xephem/Makefile
@@ -48,6 +48,17 @@ LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) $(PLATL)
 XLIBS = -lXm -lXt -lXext -lXmu -lX11
 LIBS = $(XLIBS) $(LIBLIB) -lm -lssl
 
+# Variables installation for Linux
+# For install XEphem without root permission, use a directory local
+# such $(HOME)/local or another of your preference in the prefix variable.
+ifeq ($(UNAME_S),Linux)
+  prefix = $(HOME)/local
+  bindir = $(prefix)/bin
+  datadir = $(prefix)/share
+  mandir = $(datadir)/man
+  export datadir
+endif
+
 # static linking on Apple using X11 libs from ports
 # CC = gcc
 # OLI = /opt/local/include
@@ -203,7 +214,7 @@ xephem: $(INCS) $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
 xephem.1: xephem.man
-	nroff -man $? > $@
+	cp $? $@
 
 libs:
 	cd ../../libastro; make
@@ -218,3 +229,24 @@ clean:
 
 clobber: clean
 	rm -fr xephem xephem.1
+
+# Installation in Linux systems
+ifeq ($(UNAME_S),Linux)
+install: install-binary install-man install-data install-desktopfiles
+
+install-binary:
+	install -Dm 755 xephem -t $(DESTDIR)$(bindir)
+
+install-man:
+	install -Dm 644 xephem.1 -t $(DESTDIR)$(mandir)/man1
+
+install-data:
+	install -dm 755 $(DESTDIR)$(datadir)/xephem
+	@for d in auxil catalogs fifos fits gallery help lo; do \
+	  echo "cp -R $$d $(DESTDIR)$(datadir)/xephem"; \
+	  cp -R $$d $(DESTDIR)$(datadir)/xephem; \
+	done
+
+install-desktopfiles:
+	cd ../../desktopfiles; make DESTDIR=$(DESTDIR) install
+endif

--- a/desktopfiles/Makefile
+++ b/desktopfiles/Makefile
@@ -1,0 +1,39 @@
+# Makefile for manage desktop files
+#
+# Requires convert program of the package ImageMagick.
+
+CONVERT = convert
+
+SRCPNGICON = ../GUI/xephem/XEphem.png
+PNGICONS = \
+	32x32/apps/xephem.png \
+	48x48/apps/xephem.png \
+	64x64/apps/xephem.png \
+	128x128/apps/xephem.png
+DESKTOPFILE = io.github.xephem.desktop
+METAINFOFILE = io.github.xephem.metainfo.xml
+
+iconsdir = $(DESTDIR)$(datadir)/icons/hicolor
+applicationsdir = $(DESTDIR)$(datadir)/applications
+metainfodir = $(DESTDIR)$(datadir)/metainfo
+
+
+all:
+
+install: install-icons install-desktopfile install-metainfo
+
+install-icons: $(PNGICONS)
+
+$(PNGICONS): $(SRCPNGICON)
+	@d=$(iconsdir)/$(shell dirname $@); \
+	s=$(shell echo $@ | sed -e 's/[a-z]*\([0-9]*\).*/\1/'); \
+	echo "install -m 755 -d $$d"; \
+	install -m 755 -d $$d; \
+	echo "convert -geometry $${s}x$${s} -depth 8 -background none $< $(iconsdir)/$@"; \
+	$(CONVERT) -geometry $${s}x$${s} -depth 8 -background none $< $(iconsdir)/$@
+
+install-desktopfile:
+	install -Dm 644 $(DESKTOPFILE) -t $(applicationsdir)
+
+install-metainfo:
+	install -Dm 644 $(METAINFOFILE) -t $(metainfodir)

--- a/desktopfiles/io.github.xephem.desktop
+++ b/desktopfiles/io.github.xephem.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=XEphem
+GenericName=X Window Ephemeris
+GenericName[es]=Ventana X de Efemérides
+Comment=Interactive astronomical ephemeris software
+Comment[es]=Software Interactivo de efemérides astrónomicas
+Exec=xephem
+Icon=xephem
+Terminal=false
+Categories=Science;Astronomy;Motif;
+Keywords=Astronomy;

--- a/desktopfiles/io.github.xephem.metainfo.xml
+++ b/desktopfiles/io.github.xephem.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023-2024 Miguel Molina <mmolina.unphysics@gmail.com> -->
+<component type="desktop-application">
+  <id>io.github.xephem.desktop</id>
+  <name>XEphem</name>
+  <name xml:lang="es">XEphem</name>
+  <summary>Interactive astronomical ephemeris software</summary>
+  <summary xml:lang="es">Software interactivo de efemérides astronómicas</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>
+      <ul>
+	<li><em>XEphem</em> is an interactive astronomy program for all UNIX platforms, written and maintained by _Elwood Downey_ over more than thirty years 1990-2021 and now generously released under the MIT License.</li>
+	<li><em>XEphem</em> can compute information on demand or time can be set to increment automatically. In this way a series of computations and movies can be generated.</li>
+      </ul>
+    </p>
+    <p xml:lang="es">
+      <ul>
+	<li><em>XEphem</em> es un programa de astronomía interactivo para todas las plataformas UNIX, escrito y mantenido por _Elwood Downey_ durante más de treinta años entre 1990 y 2021 y ahora publicado generosamente bajo la licencia MIT.</li>
+	<li><em>XEphem</em> puede calcular información bajo demanda o se puede configurar automáticamente en el tiempo. De esta forma se pueden generar una serie de cálculos y animaciones.</li>
+      </ul>	
+    </p>
+  </description>
+  <launchable type="desktop-id">xephem.desktop</launchable>
+  <url type="homepage">https://xephem.github.io/XEphem/Site/xephem.html</url>
+  <url type="help">https://xephem.github.io/XEphem/Site/help/xephem.html</url>
+  <update_contact>xephem@ClearSkyInstitute.com</update_contact>
+  <developer_name>Elwood Charles Downey</developer_name>
+  <releases>
+    <release date="2024-02-13" version="4.2.0"/>
+  </releases>
+  <provides>
+    <binary>xephem</binary>
+  </provides>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/XEphem/XEphem/main/GUI/xephem/help/png/sky-view.png</image>
+      <caption>Highly configurable interactive Sky View</caption>
+      <caption xml:lang="es">Vista del cielo interactivo altamente configurable</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/XEphem/XEphem/main/GUI/xephem/help/png/solsys.png</image>
+      <caption>3D projection and true stereo views of the solar system, perfect for visualizing comet paths</caption>
+      <caption xml:lang="es">Proyecciones 3D y vistas estereográficas reales del sistema solar, perfectas para visualizar trayectorias de cometas</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/XEphem/XEphem/main/GUI/xephem/help/png/sun-view.png</image>
+      <caption>Near real-time Solar images from the SOHO spacecraft</caption>
+      <caption xml:lang="es">Imágenes solares en tiempo real desde la nave espacial SOHO</caption>
+    </screenshot>
+  </screenshots>
+</component>


### PR DESCRIPTION
This PR is a new contribution which adds the desktop and AppStream metadata files (exclusively) for XEphem and its integration with the source code.
In this revision, the modifications in the `Makefile` only affect Linux platforms, using the `uname -s` command, so not to affect the compilation for other platforms.