### PR TITLE
replace K&C function style declarations by ANSI-C

### DIFF
--- a/GUI/xephem/aavso.c
+++ b/GUI/xephem/aavso.c
@@ -93,8 +93,7 @@ av_manage ()
 
 /* find the closest LISTROWS stars to op in AAVSO database and load dialog */
 void
-av_load (op)
-Obj *op;
+av_load (Obj * op)
 {
 	typedef struct {
 	    char line[DESCOLS+NAMCOLS];	/* designation in avdb file */
@@ -206,8 +205,7 @@ openDB()
 
 /* called to put up or remove the watch cursor.  */
 void
-av_cursor (c)
-Cursor c;
+av_cursor (Cursor c)
 {
 	Window win;
 
@@ -335,8 +333,7 @@ av_create()
 
 /* construct the top section */
 static void
-mkTop (rc_w)
-Widget rc_w;
+mkTop (Widget rc_w)
 {
 	Widget lrc_w, rrc_w, orc_w;
 	Widget f_w, w;
@@ -441,10 +438,7 @@ Widget rc_w;
 /* callback from the Close PB */
 /* ARGSUSED */
 static void
-av_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+av_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (av_w);
 }
@@ -452,10 +446,7 @@ XtPointer call;
 /* callback from the Print PB */
 /* ARGSUSED */
 static void
-av_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+av_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (curve_pm)
 	    XPSAsk ("AAVSO", av_print);
@@ -492,10 +483,7 @@ av_print()
  */
 /* ARGSUSED */
 static void
-av_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+av_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Fetch and display light curves from AAVSO."
@@ -508,10 +496,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-av_list_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+av_list_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmListCallbackStruct *lp = (XmListCallbackStruct *)call;
 	char *str;
@@ -532,10 +517,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-av_go_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+av_go_cb (Widget w, XtPointer client, XtPointer call)
 {
 	fetchAndShow();
 }
@@ -546,10 +528,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-av_name_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+av_name_cb (Widget w, XtPointer client, XtPointer call)
 {
 	String name;
 	char buf[1024];
@@ -596,11 +575,7 @@ XtPointer call;
 
 /* create a prompt/text field pair */
 static void
-mkPrompt (parent, prompt, text_wp, txtname)
-Widget parent;
-char *prompt;
-Widget *text_wp;
-char *txtname;
+mkPrompt (Widget parent, char * prompt, Widget * text_wp, char * txtname)
 {
 	Widget l_w, t_w, f_w;
 	Arg args[20];
@@ -639,9 +614,7 @@ char *txtname;
 
 /* build the query date string from the user's string */
 static void
-buildDateString (ustr, dstr, def)
-char *ustr, dstr[];
-char *def;
+buildDateString (char * ustr, char dstr[], char * def)
 {
 	/* skip leading blanks */
 	while (*ustr == ' ')
@@ -807,8 +780,7 @@ fetchpm()
 
 /* given a line from the avdb file strip of unwanted chars */
 static void
-cleanLine (line)
-char *line;
+cleanLine (char * line)
 {
 	char *p;
 

--- a/GUI/xephem/annotmenu.c
+++ b/GUI/xephem/annotmenu.c
@@ -168,8 +168,7 @@ ano_newres()
 }
 
 void
-ano_cursor(c)
-Cursor c;
+ano_cursor(Cursor c)
 {
 	Window win;
 
@@ -467,10 +466,7 @@ ano_mkgcs()
  */
 /* ARGSUSED */
 static void
-ano_del_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_del_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int ai = (long int)client;
 	AnnInfo *ap = &anninfo[ai];
@@ -485,10 +481,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_hide_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_hide_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int set = XmToggleButtonGetState (w);
 	int ai = (long int)client;
@@ -502,10 +495,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_new_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_new_cb (Widget w, XtPointer client, XtPointer call)
 {
 	(void) ano_newEntry();
 }
@@ -514,10 +504,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_togglehides_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_togglehides_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i;
 
@@ -533,10 +520,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_hideall_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_hideall_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i;
 
@@ -553,10 +537,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_place_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_place_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int ai = (long int)client;
 	AnnInfo *ap = &anninfo[ai];
@@ -569,10 +550,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_text_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_text_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int ai = (long int)client;
 	AnnInfo *ap = &anninfo[ai];
@@ -587,10 +565,7 @@ XtPointer call;
 /* callback from the main Close button */
 /* ARGSUSED */
 static void
-ano_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do all he work */
 	XtPopdown (anoshell_w);
@@ -601,10 +576,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_load_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_load_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 	get_xmstring (w, XmNlabelString, &fn);
@@ -617,10 +589,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024], *fn;
 	char *txt;
@@ -647,10 +616,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* TODO erase all ? */
 }
@@ -659,10 +625,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ano_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ano_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Enter text, click Place, move cursor to position text, click and hold,",

--- a/GUI/xephem/broadcast.c
+++ b/GUI/xephem/broadcast.c
@@ -16,8 +16,7 @@
  * allow for nested requests.
  */
 void
-watch_cursor(want)
-int want;
+watch_cursor(int want)
 {
 	static Cursor wc;
 	static int nreqs;
@@ -84,9 +83,7 @@ int want;
 
 /* update stuff on all major views because time has changed */
 void
-all_update(np, how_much)
-Now *np;
-int how_much;
+all_update(Now * np, int how_much)
 {
 	watch_cursor (1);
 
@@ -126,8 +123,7 @@ all_newfavs()
  * appended is true if it grew; else it was deleted.
  */
 void
-all_newdb(appended)
-int appended;
+all_newdb(int appended)
 {
 	watch_cursor (1);
 
@@ -155,8 +151,7 @@ int appended;
  * selected.
  */
 void
-all_selection_mode(whether)
-int whether;
+all_selection_mode(int whether)
 {
 	dm_selection_mode(whether);
 	mm_selection_mode(whether);
@@ -175,8 +170,7 @@ int whether;
  * this is just to collect in one place all the modules that gather care.
  */
 void
-register_selection (name)
-char *name;
+register_selection (char * name)
 {
 	plt_selection (name);
 	lst_selection (name);
@@ -187,11 +181,7 @@ char *name;
  * N.B. only send `value' to plot and search if logv is not 0.
  */
 void
-field_log (w, value, logv, str)
-Widget w;
-double value;
-int logv;
-char *str;
+field_log (Widget w, double value, int logv, char * str)
 {
 	char *name;
 

--- a/GUI/xephem/calmenu.c
+++ b/GUI/xephem/calmenu.c
@@ -57,8 +57,7 @@ static Pixel fg_pix, bg_pix;		/* used to reverse colors "today" */
 /* create a calendar from parent and return the outtermost widget.
  */
 Widget
-calm_create (parent)
-Widget parent;
+calm_create (Widget parent)
 {
 	Arg args[20];
 	Widget form_w;
@@ -260,8 +259,7 @@ calm_newres()
  * only really do it if f_ison() changed or f_ison() now and day changed.
  */
 void
-calm_set (np)
-Now *np;
+calm_set (Now * np)
 {
 	static double last_jd = -1e5;
 	static double last_tz = 1e10;
@@ -405,10 +403,7 @@ Now *np;
  */
 /* ARGSUSED */
 static void
-today_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+today_cb (Widget w, XtPointer client, XtPointer call)
 {
 	TodayCuts c = (TodayCuts)client;
 	Now *np = mm_get_now();
@@ -453,10 +448,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-date_changed_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+date_changed_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Now *np = mm_get_now();
 	int code = (long int)client;
@@ -501,10 +493,7 @@ XtPointer call;
  * of the first day of this month and nd is number of days of month `m'.
  */
 static void
-mm_nfmoon (jd, tzone, m, f, nd)
-double jd;
-double tzone;
-int m, f, nd;
+mm_nfmoon (double jd, double tzone, int m, int f, int nd)
 {
 	static char nms[] = "NM", fms[] = "FM";
 	double jdn, jdf;	/* mjd of new and full moons near jd */

--- a/GUI/xephem/closemenu.c
+++ b/GUI/xephem/closemenu.c
@@ -110,9 +110,7 @@ c_manage()
  */
 /* ARGSUSED */
 void
-c_update (np, force)
-Now *np;
-int force;
+c_update (Now * np, int force)
 {
 	if (!isUp(cshell_w) || !XmToggleButtonGetState (autoup_w))
 	    return;
@@ -123,8 +121,7 @@ int force;
 
 /* called to put up or remove the watch cursor.  */
 void
-c_cursor (c)
-Cursor c;
+c_cursor (Cursor c)
 {
 	Window win;
 
@@ -434,10 +431,7 @@ c_create_shell ()
 /* called when the general help key is pressed */
 /* ARGSUSED */
 static void
-c_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Select desired max separation and viewpoint, then Control->Start to find all",
@@ -452,10 +446,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-c_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -463,10 +454,7 @@ XtPointer call;
 /* callback from file List control button. */
 /* ARGSUSED */
 static void
-c_flist_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_flist_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (flist_w);
 }
@@ -474,10 +462,7 @@ XtPointer call;
 /* called when our toplevel shell is popped down */
 /* ARGSUSED */
 static void
-c_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XtIsManaged(flist_w))
 	    XtUnmanageChild (flist_w);
@@ -486,10 +471,7 @@ XtPointer call;
 /* called when the Close pushbutton is activated */
 /* ARGSUSED */
 static void
-c_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let the popdown do the rest of the work */
 	XtPopdown (cshell_w);
@@ -498,10 +480,7 @@ XtPointer call;
 /* called when a list item is double-clicked */
 /* ARGSUSED */
 static void
-c_actlist_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_actlist_cb (Widget w, XtPointer client, XtPointer call)
 {
 	(void) sky_point();
 }
@@ -509,10 +488,7 @@ XtPointer call;
 /* called when the Sky Point pushbutton is activated */
 /* ARGSUSED */
 static void
-c_skypoint_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_skypoint_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (sky_point() < 0)
 	    xe_msg (1, "First select a line from the list.");
@@ -521,10 +497,7 @@ XtPointer call;
 /* called when the Perform Search pushbutton is activated */
 /* ARGSUSED */
 static void
-c_go_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_go_cb (Widget w, XtPointer client, XtPointer call)
 {
 	do_search();
 }
@@ -646,13 +619,13 @@ do_search()
 
 /* retrieve the desired separation and other user option settings.
  * return 0 if ok, else -1
+* @param sp max separation, rads
+* @param mp limiting magnitude
+* @param wp wanderer flag
+* @param op ownmoons flag
  */
 static int
-get_options (sp, mp, wp, op)
-double *sp;	/* max separation, rads */
-double *mp;	/* limiting magnitude */
-int *wp;	/* wanderer flag */
-int *op;	/* ownmoons flag */
+get_options (double * sp, double * mp, int *wp, int *op)
 {
 	char *str;
 
@@ -680,9 +653,7 @@ int *op;	/* ownmoons flag */
  * allow for NULL pointers at any step.
  */
 static void
-free_band (bp, nb)
-Band bp[];
-int nb;
+free_band (Band bp[], int nb)
 {
 	Band *bpsav = bp;
 
@@ -704,10 +675,7 @@ int nb;
  * N.B. caller must free_band(*bpp) if we return >= 0.
  */
 static int
-init_bands (sep, mag, bpp)
-double sep;
-double mag;
-Band **bpp;
+init_bands (double sep, double mag, Band **bpp)
 {
 #define	BAND(x)		((int)floor(((x)+PI/2)/bandsiz))
 	int topo = pref_get (PREF_EQUATORIAL) == PREF_TOPO;
@@ -790,9 +758,7 @@ Band **bpp;
  * return 0 if ok, else xe_msg() and -1.
  */
 static int
-add_obj (bp, op)
-Band *bp;
-Obj *op;
+add_obj (Band * bp, Obj *op)
 {
 #define	BCHUNKS	32	/* grow the Obj * list at opp this much at a time */
 
@@ -833,15 +799,15 @@ Obj *op;
 /* malloc and fill *ppp with the close pairs in the sorted bands.
  * return count of new items in *ppp if ok else -1.
  * N.B. caller must free *ppp if it is != NULL no matter what we return.
+@param bp[];      list of bands to scan
+@param nb;                 number of bands
+@param maxsep;  max sep we are looking for, rads
+@param wander;     1 if limit to pairs with at least one wanderer (ss object)
+@param ownmoons;   1 if limit planets with their own moons
+@param **ppp;     return list of pairs we malloc
  */
 static int
-find_close (bp, nb, maxsep, wander, ownmoons, ppp)
-Band bp[];	/* list of bands to scan */
-int nb;		/* number of bands */
-double maxsep;	/* max sep we are looking for, rads */
-int wander;	/* 1 if limit to pairs with at least one wanderer (ss object) */
-int ownmoons;	/* 1 if limit planets with their own moons */
-Pair **ppp;	/* return list of pairs we malloc */
+find_close (Band bp[], int nb, double maxsep, int wander, int ownmoons, Pair **ppp)
 {
 	double stopsep = maxsep*2.3; /* stop scan at maxsep*sqrt(1**2 + 2**2) */
 	int m = 0;		/* n pairs there are room for in *ppp */
@@ -917,14 +883,14 @@ Pair **ppp;	/* return list of pairs we malloc */
  * put the smaller of op1/2 in slot op1 for later dup checking.
  * return 0 if ok, else -1.
  * N.B. the caller must free *ppp if it is not NULL no matter what we return.
+@param *op1, *op2;	the two objects to report 
+@param sep;	separation, rads 
+@param **ppp;	pointer to malloced list of lines 
+@param *mp;	pointer to number of Pairs already in *ppp 
+@param *np;	pointer to number of *ppp actually in use
  */
 static int
-add_pair (op1, op2, sep, ppp, mp, np)
-Obj *op1, *op2;	/* the two objects to report */
-double sep;	/* separation, rads */
-Pair **ppp;	/* pointer to malloced list of lines */
-int *mp;	/* pointer to number of Pairs already in *ppp */
-int *np;	/* pointer to number of *ppp actually in use */
+add_pair (Obj * op1, Obj * op2, double sep, Pair **ppp, int * mp, int * np)
 {
 #define	PCHUNKS	32	/* grow the report list this many at a time */
 	Pair *newp;
@@ -1018,10 +984,7 @@ pair_cmpf (const void *v1, const void *v2)
  * return 0 if ok else -1.
  */
 static int
-dspl_pairs (pp, np, sep)
-Pair pp[];
-int np;
-double sep;
+dspl_pairs (Pair pp[], int np, double sep)
 {
 	XmString *xmstrtbl;
 	char buf[128];
@@ -1117,10 +1080,7 @@ c_create_flist_w()
 /* called when the Ok button is hit in the file flist prompt */
 /* ARGSUSED */
 static void
-c_flistok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+c_flistok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024];
 	int icount;
@@ -1175,9 +1135,7 @@ flistok_overwrite_cb ()
 
 /* open the named flist file "a" or "w" and fill it in. */
 static void
-make_flist (name, how)
-char *name;
-char *how;
+make_flist (char * name, char * how)
 {
 	FILE *fp = fopend (name, NULL, how);
 
@@ -1192,8 +1150,7 @@ char *how;
 
 /* write out all objects currently in the list, with header, to fp */
 static void
-write_flist (fp)
-FILE *fp;
+write_flist (FILE * fp)
 {
 	XmStringTable items;
 	int icount;

--- a/GUI/xephem/compiler.c
+++ b/GUI/xephem/compiler.c
@@ -123,9 +123,7 @@ static int good_prog;	/* != 0 when program appears to be good */
  * else return -1 and a reason message in errbuf.
  */
 int
-compile_expr (ex, errbuf)
-char *ex;
-char *errbuf;
+compile_expr (char * ex, char * errbuf)
 {
 	/* init the globals.
 	 * also delete any flogs used in the previous program.
@@ -157,9 +155,7 @@ char *errbuf;
  * why not message in errbuf.
  */
 int
-execute_expr (vp, errbuf)
-double *vp;
-char *errbuf;
+execute_expr (double * vp, char * errbuf)
 {
 	int s;
 
@@ -188,9 +184,7 @@ prog_isgood()
  * don't stop when see the first one because a term might appear more than once.
  */
 void
-compiler_log (name, value)
-char *name;
-double value;
+compiler_log (char * name, double value)
 {
 	Var *vp;
 
@@ -365,8 +359,7 @@ skip_double()
  * if error, fill in a message in err_msg[] and return ERR.
  */
 static int
-compile (prec)
-int prec;
+compile (int prec)
 {
 	int expect_binop = 0;	/* set after we have seen any operand.
 				 * used by SUB so it can tell if it really 
@@ -499,8 +492,7 @@ int prec;
  * else return -1 with a reason why not message in err_msg.
  */
 static int
-execute(result)
-double *result;
+execute(double * result)
 {
 	int instr; 
 
@@ -572,9 +564,7 @@ double *result;
  * when return, leave lcexpr alone but move cexpr to just after the second '"'.
  */
 static int
-parse_fieldname (name, len)
-char name[];
-int len;
+parse_fieldname (char name[], int len)
 {
 	char c = '\0';
 

--- a/GUI/xephem/coordsmenu.c
+++ b/GUI/xephem/coordsmenu.c
@@ -67,9 +67,7 @@ cc_manage ()
 
 /* new main Now: hold ra/dec and update alt/az */
 void
-cc_update (np, how_much)
-Now *np;
-int how_much;
+cc_update (Now * np, int how_much)
 {
 	if (!isUp(ccshell_w))
 	    return;
@@ -79,8 +77,7 @@ int how_much;
 
 /* called to put up or remove the watch cursor.  */
 void
-cc_cursor (c)
-Cursor c;
+cc_cursor (Cursor c)
 {
 	Window win;
 
@@ -318,10 +315,7 @@ cc_create()
 
 /* callback to Point sky at current coords */
 static void
-cc_point_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_point_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Now *np = mm_get_now();
 	double e = epoch == EOD ? mjd : epoch;
@@ -355,10 +349,7 @@ XtPointer call;
 
 /* how each field is formatted, depends on Hours or Degrees */
 static void
-canonFmt (buf, v, h)
-char buf[];
-double v;
-int h;
+canonFmt (char buf[], double v, int h)
 {
 	if (h)
 	    fs_sexa (buf, v, 4, 360000);
@@ -370,10 +361,7 @@ int h;
 
 /* callback to load from current Sky View center */
 static void
-cc_getsky_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_getsky_cb (Widget w, XtPointer client, XtPointer call)
 {
 	double fov, alt, az, ra, dec;
 	char buf[32];
@@ -400,9 +388,7 @@ XtPointer call;
 
 /* redisplay TF's sexagesimal value prettied up */
 static void
-reFormat (w, h)
-Widget w;
-int h;
+reFormat (Widget w, int h)
 {
 	char buf[32], *p;
 	double x;
@@ -434,10 +420,7 @@ canonAll()
 
 /* called to place an eyepiece at these coords on the sky view */
 static void
-cc_eyep_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_eyep_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Now *np = mm_get_now();
 	double fov, ra, dec, alt, az;
@@ -493,29 +476,20 @@ XtPointer call;
 
 /* called from either the Reformat PB or Enter from any TF */
 static void
-cc_canonFormat_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_canonFormat_cb (Widget w, XtPointer client, XtPointer call)
 {
 	canonAll();
 }
 
 static void
-cc_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do all the work */
 	XtPopdown (ccshell_w);
 }
 
 static void
-cc_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 }
 
@@ -523,10 +497,7 @@ XtPointer call;
  * N.B. do not use call, used by different callbacks.
  */
 static void
-cc_vchg_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_vchg_cb (Widget w, XtPointer client, XtPointer call)
 {
 	cc_newval (w);
 }
@@ -535,10 +506,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-cc_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cc_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = { "Type in any field and the others are updated",};
 
@@ -549,8 +517,7 @@ XtPointer call;
  * remember in lastchg_w which widget was used to freeze it for next update.
  */
 static void
-cc_newval (w)
-Widget w;
+cc_newval (Widget w)
 {
 	Now *np = mm_get_now();
 	double e = (epoch == EOD) ? mjd : epoch;

--- a/GUI/xephem/datamenu.c
+++ b/GUI/xephem/datamenu.c
@@ -184,9 +184,7 @@ dm_manage ()
  * don't bother if it doesn't exist or is unmanaged now or no one is logging.
  */
 void
-dm_update (np, how_much)
-Now *np;
-int how_much;
+dm_update (Now * np, int how_much)
 {
 	int i;
 
@@ -225,10 +223,10 @@ dm_newfavs()
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 void
-dm_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+dm_selection_mode (int whether)
 {
 	if (whether)
 	    dm_selecting++;
@@ -273,10 +271,7 @@ dm_resetuhzndep()
  * this takes into account the options currently in effect with the Data menu.
  */
 void
-dm_riset (np, op, rsp)
-Now *np;
-Obj *op;
-RiseSet *rsp;
+dm_riset (Now * np, Obj * op, RiseSet * rsp)
 {
 	double dis;	/* rads apparent horizon is above true */
 
@@ -296,8 +291,7 @@ RiseSet *rsp;
 
 /* called to put up or remove the watch cursor.  */
 void
-dm_cursor (c)
-Cursor c;
+dm_cursor (Cursor c)
 {
 	Window win;
 
@@ -322,9 +316,7 @@ Cursor c;
  * return 0 if column is on, else -1
  */
 int
-dm_colHeader (c, str)
-DMCol c;
-char str[];
+dm_colHeader (DMCol c, char str[])
 {
 	if (!col[c].on)
 	    return (-1);
@@ -336,12 +328,7 @@ char str[];
  * return 0 if column is on, else -1 (but always fill in str).
  */
 int
-dm_colFormat (np, op, rp, c, str)
-Now *np;
-Obj *op;
-RiseSet *rp;
-DMCol c;
-char str[];
+dm_colFormat (Now * np, Obj * op, RiseSet *rp, DMCol c, char str[])
 {
 	static Widget w;
 	char *lstr;
@@ -580,10 +567,7 @@ dm_create_shell()
 /* callback to bring up the Data setup dialog */
 /* ARGSUSED */
 void
-dm_setup_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_setup_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!selshell_w)
 	    dm_create_shell();
@@ -607,10 +591,10 @@ dm_sep (Obj *op)
 
 /* go through all the table buttons and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	 whether setting up for plotting or for not plotting 
  */
 static void
-dm_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+dm_set_buttons (int whether)
 {
 	int r, c;
 
@@ -699,10 +683,7 @@ dm_selname (Widget pb_w, int r, int c)
  */
 static void
 /* ARGSUSED */
-dm_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (dm_selecting) {
 	    char *name;
@@ -714,10 +695,7 @@ XtPointer call;
 /* callback when main dialog is popped down */
 static void
 /* ARGSUSED */
-dm_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (selshell_w && XtIsManaged (selshell_w))
 	    XtUnmanageChild (selshell_w);
@@ -732,10 +710,7 @@ XtPointer call;
  */
 static void
 /* ARGSUSED */
-dm_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do the real work */
 	XtPopdown (datashell_w);
@@ -745,10 +720,7 @@ XtPointer call;
  */
 static void
 /* ARGSUSED */
-dm_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This table displays various information about the planets and objects.",
@@ -759,13 +731,14 @@ XtPointer call;
 	hlp_dialog ("Data_Table", msg, XtNumber(msg));
 }
 
-/* compute and print body info in data menu format */
+/* compute and print body info in data menu format 
+@param r;		which row 
+@param force;	 whether to print for sure or only if things have changed 
+@param *np;
+*/
 /* ARGSUSED */
 static void
-dm_compute (r, force, np)
-int r;		/* which row */
-int force;	/* whether to print for sure or only if things have changed */
-Now *np;
+dm_compute (int r, int force, Now * np)
 {
 	int did_rs = 0;
 	RiseSet rs;
@@ -786,12 +759,7 @@ Now *np;
 }
 
 static void
-dm_format (np, op, rp, c, w)
-Now *np;
-Obj *op;
-RiseSet *rp;
-int c;
-Widget w;
+dm_format (Now * np, Obj * op, RiseSet * rp, int c, Widget w)
 {
 	static char me[] = "dm_format()";
 	double tmp;
@@ -1186,10 +1154,7 @@ dm_settags()
  * convert tm to local time if tzpref && PREF_ZONE == PREF_LOCALTZ.
  */
 static void
-dm_showtim (np, w, t)
-Now *np;
-Widget w;
-double t;
+dm_showtim (Now * np, Widget w, double t)
 {
 	if (pref_get(PREF_ZONE) == PREF_LOCALTZ)
 	    t -= tz/24.0;
@@ -1208,11 +1173,7 @@ double t;
  */
 /* ARGSUSED */
 static void
-dm_rs_hrsup (np, op, w, rp)
-Now *np;
-Obj *op;
-Widget w;
-RiseSet *rp;
+dm_rs_hrsup (Now * np, Obj * op, Widget w, RiseSet * rp)
 {
 	double r, s, up;
 
@@ -1251,10 +1212,7 @@ RiseSet *rp;
 }
 
 static void
-show_constellation (np, op, w)
-Now *np;
-Obj *op;
-Widget w;
+show_constellation (Now * np, Obj * op, Widget w)
 {
 	char nm[10], *name;
 	int id;
@@ -1267,9 +1225,7 @@ Widget w;
 
 /* compute the separation between the two sky locations */
 void
-dm_separation (p, q, sp)
-Obj *p, *q;
-double *sp;
+dm_separation (Obj * p, Obj * q, double * sp)
 {
 	double csep;
 
@@ -1280,8 +1236,7 @@ double *sp;
 
 /* create the setup dialog */
 static void
-ds_create_selection(parent)
-Widget parent;
+ds_create_selection(Widget parent)
 {
 	static struct { /* info to streamline creation of control buttons */
 	    DSCtrls id;
@@ -1637,10 +1592,7 @@ ds_apply_selections()
  */
 static void
 /* ARGSUSED */
-ds_ctl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ds_ctl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	DSCtrls id = (DSCtrls) client;
 	int i;
@@ -1711,10 +1663,7 @@ dm_create_flist_w()
 /* called when the Ok button is hit in the file list prompt */
 /* ARGSUSED */
 static void
-dm_flistok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_flistok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024];
 	char *name;
@@ -1761,9 +1710,7 @@ flistok_overwrite_cb ()
 
 /* open the named flist file "a" or "w" and fill it in. */
 static void
-make_flist (name, how)
-char *name;
-char *how;
+make_flist (char * name, char * how)
 {
 	FILE *fp = fopend (name, NULL, how);
 
@@ -1776,10 +1723,7 @@ char *how;
 /* callback from file List control button. */
 /* ARGSUSED */
 static void
-dm_flist_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_flist_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!flist_w)
 	    dm_create_flist_w();
@@ -1791,10 +1735,7 @@ XtPointer call;
 /* callback from x selection control button. */
 /* ARGSUSED */
 static void
-dm_xsel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+dm_xsel_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *buf = XtMalloc ((nfavs+3)*(NC*20));	/* plenty big :-) */
 	dm_list_get (buf);
@@ -1805,8 +1746,7 @@ XtPointer call;
 
 /* write the current data table to the given file */
 static void
-dm_list_tofile(fp)
-FILE *fp;
+dm_list_tofile(FILE * fp)
 {
 	char *buf = XtMalloc ((nfavs+3)*(NC*20));	/* plenty big :-) */
 	dm_list_get (buf);
@@ -1817,8 +1757,7 @@ FILE *fp;
 /* fetch the current table into the given buffer.
  */
 static void
-dm_list_get (buf)
-char buf[];
+dm_list_get (char buf[])
 {
 	Now *np = mm_get_now();
 	int maxch[NC];

--- a/GUI/xephem/db.c
+++ b/GUI/xephem/db.c
@@ -91,8 +91,7 @@ db_n()
  * updated Obj in the database.
  */
 Obj *
-db_basic(id)
-int id;
+db_basic(int id)
 {
 	Obj *op;
 
@@ -184,8 +183,7 @@ db_dups (DupName **dnpp)
  * N.B. dbcp not valid on return
  */
 void
-db_catdel (dbcp)
-DBCat *dbcp;
+db_catdel (DBCat * dbcp)
 {
 	int t, c;
 
@@ -242,8 +240,7 @@ db_opfindcat (Obj *op)
  * if find it return pointer to DBCat, else return NULL.
  */
 static DBCat *
-db_nmfindcat (name)
-char *name;
+db_nmfindcat (char * name)
 {
 	char *base;
 	int i;
@@ -267,8 +264,7 @@ char *name;
  * return pointer if ok, else NULL if no more memory.
  */
 static DBCat *
-db_catadd (name)
-char *name;
+db_catadd (char* name)
 {
 	DBCat *dbcp;
 	int i;
@@ -325,11 +321,7 @@ db_invalidate()
  * N.B. nothing should be assumed as to the order these are returned.
  */
 void
-db_scaninit (sp, tmask, op, nop)
-DBScan *sp;
-int tmask;
-ObjF *op;
-int nop;
+db_scaninit (DBScan * sp, int tmask, ObjF * op, int nop)
 {
 	if (!DBINITED)
 	    db_init();
@@ -346,8 +338,7 @@ int nop;
  * N.B. the s_ fields are *not* updated -- call db_update() when you need that.
  */
 Obj *
-db_scan (sp)
-DBScan *sp;
+db_scan (DBScan * sp)
 {
 	if (!DBINITED)
 	    db_init();
@@ -389,8 +380,7 @@ DBScan *sp;
  *   although we guarantee an actual update occurs if it's not.
  */
 void
-db_update(op)
-Obj *op;
+db_update(Obj * op)
 {
 	static char me[] = "db_update()";
 
@@ -466,8 +456,7 @@ db_del_all()
  * N.B. caller is responsible for calling all_newdb().
  */
 void
-db_read (fn)
-char *fn;
+db_read (char * fn)
 {
 	char bufs[3][MAXDBLINE];
 	char *brot, *b0 = bufs[0], *b1 = bufs[1], *b2 = bufs[2];
@@ -710,13 +699,13 @@ DBCatObj (DBCat *dbcp, int t, int i)
  * N.B. do EXACTLY ONE read -- don't know that more won't block.
  * set the watch cursor while we work and call all_newdb() when we're done.
  *   we guess we are "done" when we end up without a partial line.
+@param client;       file name 
+@param *fdp;               pointer to file descriptor 
+@param *idp;         pointer to input id 
  */
 /* ARGSUSED */
 static void
-dbfifo_cb (client, fdp, idp)
-XtPointer client;       /* file name */
-int *fdp;               /* pointer to file descriptor */
-XtInputId *idp;         /* pointer to input id */
+dbfifo_cb (XtPointer client, int * fdp, XtInputId * idp)
 {
 	static char partial[MAXDBLINE];	/* partial line from before */
 	static int npartial;		/* length of stuff in partial[] */

--- a/GUI/xephem/dbmenu.c
+++ b/GUI/xephem/dbmenu.c
@@ -68,8 +68,7 @@ db_manage()
  */
 /* ARGSUSED */
 void
-db_newdb (appended)
-int appended;
+db_newdb (int appended)
 {
 	if (isUp(dbshell_w))
 	    db_set_report();
@@ -87,9 +86,7 @@ db_chkAltNames(void)
 /* update the list of catalogs.
  */
 void
-db_newcatmenu (dbcp, ndbcp)
-DBCat dbcp[];
-int ndbcp;
+db_newcatmenu (DBCat dbcp[], int ndbcp)
 {
 	char buf[128];
 	Arg args[20];
@@ -123,8 +120,7 @@ int ndbcp;
 
 /* called to put up or remove the watch cursor.  */
 void
-db_cursor (c)
-Cursor c;
+db_cursor (Cursor c)
 {
 	Window win;
 
@@ -392,10 +388,7 @@ db_create_shell ()
 /* a PB in a file PD has been chosen.
  */
 static void
-db_loadpb_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+db_loadpb_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 
@@ -511,10 +504,7 @@ dbdelall()
  */
 /* ARGSUSED */
 static void
-db_index_cb (w, client, data)
-Widget w;
-XtPointer client;
-XtPointer data;
+db_index_cb (Widget w, XtPointer client, XtPointer data)
 {
 	obj_manage();
 }
@@ -523,10 +513,7 @@ XtPointer data;
  */
 /* ARGSUSED */
 static void
-db_delall_cb (w, client, data)
-Widget w;
-XtPointer client;
-XtPointer data;
+db_delall_cb (Widget w, XtPointer client, XtPointer data)
 {
 	if (confirm())
 	    query (dbshell_w, "Delete all files from memory?",
@@ -549,10 +536,7 @@ dbrelall()
  */
 /* ARGSUSED */
 static void
-db_relall_cb (w, client, data)
-Widget w;
-XtPointer client;
-XtPointer data;
+db_relall_cb (Widget w, XtPointer client, XtPointer data)
 {
 	if (confirm())
 	    query (dbshell_w, "Reload all files in memory?",
@@ -565,20 +549,14 @@ XtPointer data;
 /* callback from the open fifo button */
 /* ARGSUSED */
 static void
-db_openfifo_cb (w, client, data)
-Widget w;
-XtPointer client;
-XtPointer data;
+db_openfifo_cb (Widget w, XtPointer client, XtPointer data)
 {
 	db_connect_fifo();
 }
 
 /* ARGSUSED */
 static void
-db_help_cb (w, client, data)
-Widget w;
-XtPointer client;
-XtPointer data;
+db_help_cb (Widget w, XtPointer client, XtPointer data)
 {
 	static char *msg[] = {
 "This displays a count of the various types of objects currently in memory.",
@@ -593,20 +571,14 @@ XtPointer data;
  */
 /* ARGSUSED */
 static void
-db_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+db_helpon_cb (Widget w, XtPointer client, XtPointer data)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
 
 /* ARGSUSED */
 static void
-db_popdown_cb (w, client, data)
-Widget w;
-XtPointer client;
-XtPointer data;
+db_popdown_cb (Widget w, XtPointer client, XtPointer data)
 {
 	if (dbf_w)
 	    XtUnmanageChild (dbf_w);
@@ -614,10 +586,7 @@ XtPointer data;
 
 /* ARGSUSED */
 static void
-db_close_cb (w, client, data)
-Widget w;
-XtPointer client;
-XtPointer data;
+db_close_cb (Widget w, XtPointer client, XtPointer data)
 {
 	XtPopdown (dbshell_w);
 }
@@ -627,10 +596,7 @@ XtPointer data;
  */
 /* ARGSUSED */
 static void
-catdel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+catdel_cb (Widget w, XtPointer client, XtPointer data)
 {
 	watch_cursor(1);
 	db_catdel ((DBCat *)client);
@@ -643,10 +609,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-cathdr_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cathdr_cb (Widget w, XtPointer client, XtPointer data)
 {
 	watch_cursor(1);
 	db_showhdr (((DBCat *)client)->name);
@@ -655,9 +618,7 @@ XtPointer call;
 
 /* build one new catalog entry */
 static void
-db_1catrow (rc_w, dbcp)
-Widget rc_w;
-DBCat *dbcp;
+db_1catrow (Widget rc_w, DBCat * dbcp)
 {
 	Widget f_w, pb_w;
 	Widget nl_w, cl_w;

--- a/GUI/xephem/earthmenu.c
+++ b/GUI/xephem/earthmenu.c
@@ -390,9 +390,7 @@ e_manage()
  * remove all trail history if any.
  */
 void
-e_update(np, force)
-Now *np;
-int force;
+e_update(Now * np, int force)
 {
 	EObj *eop;
 
@@ -454,8 +452,7 @@ e_newfavs()
  * so we rebuild the favorites list.
  */
 void
-e_newdb (appended)
-int appended;
+e_newdb (int appended)
 {
 	if (!eshell_w)
 	    return;
@@ -468,8 +465,7 @@ int appended;
  * the ons and offs stack.
  */
 void
-e_selection_mode (whether)
-int whether;
+e_selection_mode (int whether)
 {
 	if (whether)
 	    e_selecting++;
@@ -483,8 +479,7 @@ int whether;
 }
 
 void
-e_cursor(c)
-Cursor c;
+e_cursor(Cursor c)
 {
 	Window win;
 
@@ -531,7 +526,7 @@ e_create_shell()
 	typedef struct {
 	    char *name;
 	    char *label;
-	    void (*cb)();
+	    void (*cb)(Widget w, XtPointer client, XtPointer call);
 	    int client;
 	    Widget *wp;
 	    char *tip;
@@ -1451,10 +1446,7 @@ e_buildfavs()
 /* callback when any of the stat buttons are activated. */
 /* ARGSUSED */
 static void
-e_stat_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_stat_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (e_selecting) {
 	    char *userD;
@@ -1467,10 +1459,7 @@ XtPointer call;
 /* callback when the main form in popped down */
 /* ARGSUSED */
 static void
-e_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown(ectrl_w);
 
@@ -1491,10 +1480,7 @@ XtPointer call;
 /* callback for when the main Close button is activated */
 /* ARGSUSED */
 static void
-e_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown to the real work */
 	XtPopdown (eshell_w);
@@ -1503,10 +1489,7 @@ XtPointer call;
 /* callback for when the control dialog is closed */
 /* ARGSUSED */
 static void
-e_cclose_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_cclose_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (ectrl_w);
 }
@@ -1514,10 +1497,7 @@ XtPointer call;
 /* callback to bring up web update window */
 /* ARGSUSED */
 static void
-e_webupdate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_webupdate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	wdb_manage();
 }
@@ -1527,10 +1507,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_ontrack_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_ontrack_cb (Widget w, XtPointer client, XtPointer call)
 {
 	EObj *eop = &eobjs[(long int)client];
 
@@ -1562,10 +1539,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_onpick_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_onpick_cb (Widget w, XtPointer client, XtPointer call)
 {
 	EObj *eop;
 
@@ -1582,10 +1556,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_show_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_show_cb (Widget w, XtPointer client, XtPointer call)
 {
 	EObj *eop = &eobjs[(long int)client];
 
@@ -1611,10 +1582,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_wantlbl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_wantlbl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* if coming on, show as a courtesy */
 	if (TBISON(w)) {
@@ -1631,10 +1599,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_wantfoot_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_wantfoot_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* if coming on, show as a courtesy */
 	if (TBISON(w)) {
@@ -1651,10 +1616,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_wantorb_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_wantorb_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* if coming on, show as a courtesy */
 	if (TBISON(w)) {
@@ -1668,10 +1630,7 @@ XtPointer call;
 /* callback for when the Movie button is activated. */
 /* ARGSUSED */
 static void
-e_anim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_anim_cb (Widget w, XtPointer client, XtPointer call)
 {
 	mm_movie (MOVIE_SS);
 }
@@ -1679,20 +1638,17 @@ XtPointer call;
 /* callback to add scene to movie loop */
 /* ARGSUSED */
 static void
-e_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (e_pm, e_dt_w);
 }
 
 /* go through all the buttons and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 static void
-e_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+e_set_buttons (int whether)
 {
 	int i;
 
@@ -1712,10 +1668,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
  */
 /* ARGSUSED */
 static void
-e_mhelp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_mhelp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This is a simple schematic depiction of the Earth surface at the given time.",
@@ -1729,10 +1682,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_chelp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_chelp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Controls which objects are displayed and their current stats"
@@ -1746,10 +1696,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1758,10 +1705,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XPSAsk ("Earth", e_print);
 }
@@ -1810,8 +1754,7 @@ e_print ()
 }
 
 static void
-e_ps_annotate (np)
-Now *np;
+e_ps_annotate (Now * np)
 {
 	int unitspref = pref_get (PREF_UNITS);
 	double sslat, sslong;
@@ -1948,10 +1891,7 @@ Now *np;
 
 /* label print with center lat/long */
 static void
-e_ps_ll (tag, lt, lg, x, y)
-char *tag;
-double lt, lg;
-int x, y;
+e_ps_ll (char * tag, double lt, double lg, int x, int y)
 {
 	char ltstr[32], lgstr[32];
 	char buf[128];
@@ -1971,10 +1911,7 @@ int x, y;
  */
 /* ARGSUSED */
 static void
-e_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static unsigned last_wid, last_hei;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -2045,11 +1982,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_motion_eh (w, client, ev, continue_to_dispatch)
-Widget w;
-XtPointer client;
-XEvent *ev;
-Boolean *continue_to_dispatch;
+e_motion_eh (Widget w, XtPointer client, XEvent * ev, Boolean * continue_to_dispatch)
 {
 	static int inwin;
 	Display *dsp = XtDisplay(w);
@@ -2132,10 +2065,7 @@ Boolean *continue_to_dispatch;
  */
 /* ARGSUSED */
 static void
-e_tb_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+e_tb_cb (Widget wid, XtPointer client, XtPointer call)
 {
 	int state = TBISON (wid);
 	int want = (long int) client;
@@ -2214,10 +2144,7 @@ XtPointer call;
 /* called to open the object control window */
 /* ARGSUSED */
 static void
-e_copen_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_copen_cb (Widget w, XtPointer client, XtPointer call)
 {
 	e_set_buttons(e_selecting);
 	XtPopup (ectrl_w, XtGrabNone);
@@ -2230,10 +2157,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_trail_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_trail_cb (Widget w, XtPointer client, XtPointer call)
 {
 	EObj *eop = &eobjs[(long int)client];
 
@@ -2373,10 +2297,7 @@ e_wantorbtgl_cb (Widget w, XtPointer client, XtPointer call)
  */
 /* ARGSUSED */
 static void
-e_wxreload_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_wxreload_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (e_setupwxpm(1, 1) == 0)
 	    e_all (0);
@@ -2387,10 +2308,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_proj_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_proj_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Proj newproj = (Proj)client;
 
@@ -2559,10 +2477,7 @@ e_set_dasize()
  */
 /* ARGSUSED */
 static void
-e_setmain_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_setmain_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Now *np = mm_get_now();
 	int which = (long int)client;
@@ -2592,10 +2507,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_latlong_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_latlong_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScaleCallbackStruct *s = (XmScaleCallbackStruct *)call;
 
@@ -2619,10 +2531,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_lat0_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_lat0_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int lg;
 
@@ -2644,10 +2553,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-e_point_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+e_point_cb (Widget w, XtPointer client, XtPointer call)
 {
 	e_setelatlng (pu_info.pu_lt, pu_info.pu_lg);
 	noTrack();
@@ -2725,12 +2631,7 @@ e_copy_pm()
  */
 /* ARGSUSED */
 static void
-e_popup (wid, ev, d, xb, yb, x, y)
-Widget wid;
-XEvent *ev;
-unsigned d;
-unsigned xb, yb;
-int x, y;
+e_popup (Widget wid, XEvent * ev, unsigned d, unsigned xb, unsigned yb, int x, int y)
 {
 	Now *np = mm_get_now();
 	int mind = 10000000;		/* min pick dist so far */
@@ -3075,11 +2976,7 @@ e_create_popup()
 /* given diameter and x/y border display info at the given lat/long
  */
 static void
-e_track_latlng (w, d, xb, yb, lt, lg)
-Widget w;
-int d;
-int xb, yb;
-double lt, lg;
+e_track_latlng (Widget w, int d, int xb, int yb, double lt, double lg)
 {
 	static int last_lst_w, last_lmt_w, last_ll_w, last_db_w;
 	int topy = projection == WXMAP ? WXM_TY : 0;
@@ -3184,8 +3081,7 @@ double lt, lg;
  * -PI/2 .. elat .. PI/2 and -PI .. elng .. PI.
  */
 static void
-e_setelatlng (lt, lg)
-double lt, lg;
+e_setelatlng (double lt, double lg)
 {
 	elat = lt;
 	selat = sin(elat);
@@ -3205,10 +3101,7 @@ double lt, lg;
  * both are in rads, lat is +N, long is +E.
  */
 static void
-e_subobject(np, op, latp, longp)
-Now *np;
-Obj *op;
-double *latp, *longp;
+e_subobject(Now * np, Obj * op, double * latp, double * longp)
 {
 	if (op->o_type == EARTHSAT) {
 	    /* these are all ready to go */
@@ -3256,8 +3149,7 @@ e_edist_rate (Now *np, Obj *op)
  * turn off the display of these items.
  */
 static void
-e_show_esat_stats (eop)
-EObj *eop;
+e_show_esat_stats (EObj * eop)
 {
 	Now *np = mm_get_now();
 	Obj *op = &eop->trail[0].t_obj;
@@ -3361,13 +3253,13 @@ rd2ll (double ra, double dec, double *lp, double *Lp)
  *   x and y coords of point on screen
  * always return the coordinates, but return 1 if the point is visible or 0 if
  *   it's over the limb.
+@param d;		 diameter of drawing surface circle 
+@param wb, hb;	 width/height borders between circle and edges 
+@param pl, pL;		 point p lat, rads, +N; long, rads, +E 
+@param *xp, *yp;		 projected location onto drawing surface 
  */   
 static int
-e_coord (d, wb, hb, pl, pL, xp, yp)
-unsigned d;		/* diameter of drawing surface circle */
-unsigned wb, hb;	/* width/height borders between circle and edges */
-double pl, pL;		/* point p lat, rads, +N; long, rads, +E */
-short *xp, *yp;		/* projected location onto drawing surface */
+e_coord (unsigned d, unsigned wb, unsigned hb, double pl, double pL, short * xp, short * yp)
 {
 	switch (projection) {
 	case CYLI: /* FALLTHRU */
@@ -3418,14 +3310,14 @@ short *xp, *yp;		/* projected location onto drawing surface */
  * degrees altitude above horizon as well.
  * also draw a crosshair at the actual location.
  * return 1 if any part was visible, else 0.
+@param *np;		 circumstances 
+@param *eop;		 object info 
+@param d, wb, hb;		 dia and width/height borders of circle to use 
+@param slat, slng;	 satellite's lat and lng 
+@param el;		satellite's elevation above surface, m 
  */
 static int
-e_drawfootprint (np, eop, d, wb, hb, slat, slng, el)
-Now *np;		/* circumstances */
-EObj *eop;		/* object info */
-int d, wb, hb;		/* dia and width/height borders of circle to use */
-double slat, slng;	/* satellite's lat and lng */
-double el;		/* satellite's elevation above surface, m */
+e_drawfootprint (Now * np, EObj * eop, int d, int wb, int hb, double slat, double slng, double el)
 {
 	double rad;	/* viewing altitude radius, rads */
 	int isvis;
@@ -3447,13 +3339,13 @@ double el;		/* satellite's elevation above surface, m */
  * we do it by sweeping an arc from the given location and collecting the end
  *   points. beware going over the horizon or wrapping around the edge.
  * return 1 if any part of the circle is visible, else 0.
+@param pix;		rawing color 
+@param d, wb, hb;	ia and width/height borders of circle to use 
+@param slat, slng;	lat/long of object 
+@param rad;		angular radius of circle to draw 
  */
 static int
-e_drawcircle (pix, d, wb, hb, slat, slng, rad)
-Pixel pix;		/* drawing color */
-unsigned d, wb, hb;	/* dia and width/height borders of circle to use */
-double slat, slng;	/* lat/long of object */
-double rad;		/* angular radius of circle to draw */
+e_drawcircle (Pixel pix, unsigned d, unsigned wb, unsigned hb, double slat, double slng, double rad)
 {
 #define	MAXVCIRSEGS	62
 	XPoint xp[MAXVCIRSEGS+1];
@@ -3491,12 +3383,12 @@ double rad;		/* angular radius of circle to draw */
 
 /* draw a little crosshair or plussign at the given location with the e_olgc
  * return whether visible
+@param d, wb, hb;	dia and width/height borders of circle to use 
+@param lt, lg;		desired center location 
+@param style;		CROSSH or PLUSS 
  */
 static int
-e_drawcross (d, wb, hb, lt, lg, style)
-unsigned d, wb, hb;	/* dia and width/height borders of circle to use */
-double lt, lg;		/* desired center location */
-int style;		/* CROSSH or PLUSS */
+e_drawcross (unsigned d, unsigned wb, unsigned hb, double lt, double lg, int style)
 {
 	double lats[4], lngs[4];	/* lats and longs of endpoints */
 	XSegment xs[4];			/* one for each cardinal direction */
@@ -3577,10 +3469,11 @@ int style;		/* CROSSH or PLUSS */
 	return (1);
 }
 
-/* draw the lat/long grid lines */
+/* draw the lat/long grid lines 
+@param d, wb, hb;	dia and width/height borders of circle to use 
+*/
 static void
-e_drawgrid (d, wb, hb)
-unsigned d, wb, hb;	/* dia and width/height borders of circle to use */
+e_drawgrid (unsigned d, unsigned wb, unsigned hb)
 {
 #define	MAXGRIDSEGS	60		/* max segments per grid line */
 	int nsegs = MAXGRIDSEGS;
@@ -3621,14 +3514,14 @@ unsigned d, wb, hb;	/* dia and width/height borders of circle to use */
 /* given projection, diam and size of window and X-coord x/y, return lat/long.
  * see e_getcircle() for meanings in each projection.
  * return 1 if inside the map, else 0.
+@param proj;		which projection to use 
+@param int d;		diameter of earth limb, pixels 
+@param xb, yb;	borders around circle 
+@param x, y;		-windows coords of loc 
+@param *ltp, *lgp;	resulting lat/long, rads 
  */
 static int
-e_uncoord (proj, d, xb, yb, x, y, ltp, lgp)
-Proj proj;		/* which projection to use */
-unsigned int d;		/* diameter of earth limb, pixels */
-unsigned xb, yb;	/* borders around circle */
-int x, y;		/* X-windows coords of loc */
-double *ltp, *lgp;	/* resulting lat/long, rads */
+e_uncoord (Proj proj, unsigned int d, unsigned xb, unsigned yb, int x, int y, double * ltp, double *lgp)
 {
 	switch (proj) {
 
@@ -3709,8 +3602,7 @@ noTrack()
  * for faster redraw when we know full well the stats have not changed.
  */
 static void
-e_all (statstoo)
-int statstoo;
+e_all (int statstoo)
 {
 	Now *np = mm_get_now();
 	EObj *eop;
@@ -3763,12 +3655,12 @@ int statstoo;
  * if spherical, center a circle of max size that completely fits.
  * if cylindrical, use entire rectangle.
  * if wxmap, assume correct (fixed) size, r is horizontal half-width.
+@param *wp, *hp;			overall width and height 
+@param *dp;			circle diameter 
+@param *xbp, *ybp;			x and y border 
  */
 static void
-e_getcircle (wp, hp, dp, xbp, ybp)
-int *wp, *hp;			/* overall width and height */
-int *dp;			/* circle diameter */
-int *xbp, *ybp;			/* x and y border */
+e_getcircle (int * wp, int * hp, int * dp, int * xbp, int * ybp)
 {
 	Display *dsp = XtDisplay(e_da_w);
 	Window win = XtWindow(e_da_w);
@@ -3800,8 +3692,7 @@ int *xbp, *ybp;			/* x and y border */
 /* draw everything centered at elat/elng onto e_pm.
  */
 static void
-e_map (np)
-Now *np;
+e_map (Now * np)
 {
 	Display *dsp = XtDisplay(e_da_w);
 	int w, h, d, wb, hb;
@@ -3915,11 +3806,12 @@ e_ano (double *latp, double *longp, int *xp, int *yp, int w2x, int arg)
 	return (v);
 }
 
-/* draw the portion of the earth lit by the sun */
+/* draw the portion of the earth lit by the sun 
+@param *np;		 circumstances 
+@param int d, wb, hb;	 circle dia, width and height borders in pixmap 
+*/
 static void
-e_sunlit (np, d, wb, hb)
-Now *np;		/* circumstances */
-unsigned int d, wb, hb;	/* circle dia, width and height borders in pixmap */
+e_sunlit (Now * np, unsigned int d, unsigned int wb, unsigned int hb)
 {
 	switch (projection) {
 	case CYLI:
@@ -3941,11 +3833,11 @@ unsigned int d, wb, hb;	/* circle dia, width and height borders in pixmap */
 }
 
 /* draw the sunlit portion of the Earth in cylindrical projection.
+@param *np;		circumstances 
+@param int d, wb, hb;	circle dia, width and height borders in pixmap 
  */
 static void
-e_msunlit (np, d, wb, hb)
-Now *np;		/* circumstances */
-unsigned int d, wb, hb;	/* circle dia, width and height borders in pixmap */
+e_msunlit (Now * np, unsigned int d, unsigned int wb, unsigned int hb)
 {
 #define MAXNMPTS	256	/* n segments -- larger is finer but slower */
 	Display *dsp = XtDisplay(e_da_w);
@@ -4022,11 +3914,11 @@ unsigned int d, wb, hb;	/* circle dia, width and height borders in pixmap */
 
 /* draw the solid gibbous or crescent sun-lit portion of the Earth in spherical
  * projection.
+@param *np;		circumstances 
+@param int d, wb, hb;	circle dia, width and height borders in pixmap 
  */
 static void
-e_ssunlit (np, d, wb, hb)
-Now *np;		/* circumstances */
-unsigned int d, wb, hb;	/* circle dia, width and height borders in pixmap */
+e_ssunlit (Now * np, unsigned int d, unsigned int wb, unsigned int hb)
 {
 #define MAXNSPTS	52	/* max number of polyline points */
 #define	FULLANGLE	degrad(5)/* consider full if within this angle */
@@ -4098,8 +3990,7 @@ unsigned int d, wb, hb;	/* circle dia, width and height borders in pixmap */
 
 /* draw each continent border */
 static void
-e_drawcontinents (d, wb, hb)
-unsigned d, wb, hb;
+e_drawcontinents (unsigned d, unsigned wb, unsigned hb)
 {
 #define	MINSEP		1000	/* min sep to draw in low prec, 100ths deg */
 #define	PTCACHE		64	/* number of XPoints to cache */
@@ -4142,8 +4033,7 @@ unsigned d, wb, hb;
 
 /* draw each site */
 static void
-e_drawsites (d, wb, hb)
-unsigned d, wb, hb;
+e_drawsites (unsigned d, unsigned wb, unsigned hb)
 {
 #define	NPCACHE		64		/* number of XPoints to cache */
 	Display *dsp = XtDisplay(e_da_w);
@@ -4179,12 +4069,12 @@ unsigned d, wb, hb;
 
 /* draw all but the first object in the trails list onto e_pm relative to
  * elat/elng connected lines, with tickmarks and possible time stamps.
+@param *eop;		info about object 
+@param d;			 Earth circle diameter, pixels 
+@param wb, hb;		 width and height borders, pixels 
  */
 static void
-e_drawtrail (eop, d, wb, hb)
-EObj *eop;		/* info about object */
-int d;			/* Earth circle diameter, pixels */
-int wb, hb;		/* width and height borders, pixels */
+e_drawtrail (EObj * eop, int d, int wb,int  hb)
 {
 	int w = d + 2*wb;
 	short lx = 0, ly = 0, lv;
@@ -4268,13 +4158,13 @@ int wb, hb;		/* width and height borders, pixels */
 /* draw the first object in the trails list onto e_pm relative to elat/elng
  * with a full bullseye.
  * return 1 if any part was visible, else 0.
+@param *np;		circumstances 
+@param *eop;		which object 
+@param d;			Earth circle diameter, pixels 
+@param wb, hb;		width and height borders, pixels 
  */
 static int
-e_drawobject (np, eop, d, wb, hb)
-Now *np;		/* circumstances */
-EObj *eop;		/* which object */
-int d;			/* Earth circle diameter, pixels */
-int wb, hb;		/* width and height borders, pixels */
+e_drawobject (Now * np, EObj * eop, int d, int wb, int hb)
 {
 	Trail *tp = eop->trail;
 	int isvis;
@@ -4300,12 +4190,12 @@ int wb, hb;		/* width and height borders, pixels */
  * orbit begins over current ground location then proceeds in a sidereal
  * reference frame, ie, ignores rotation of the earth.
  * draw name if want.
+@param *eop;		which object 
+@param d;			Earth circle diameter, pixels 
+@param wb, hb;		 width and height borders, pixels 
  */
 static void
-e_draworbit (eop, d, wb, hb)
-EObj *eop;		/* which object */
-int d;			/* Earth circle diameter, pixels */
-int wb, hb;		/* width and height borders, pixels */
+e_draworbit (EObj * eop, int d, int wb, int hb)
 {
 	Now now, *np;		/* advance time through one rev */
 	Obj obj, *op;		/* advance object through one rev */
@@ -4466,12 +4356,13 @@ int wb, hb;		/* width and height borders, pixels */
 	}
 }
 
-/* draw obj's name */
+/* draw obj's name 
+@param *eop;		 which object 
+@param d;			Earth circle diameter, pixels 
+@param wb, hb;		width and height borders, pixels 
+*/
 static void
-e_drawname (eop, d, wb, hb)
-EObj *eop;		/* which object */
-int d;			/* Earth circle diameter, pixels */
-int wb, hb;		/* width and height borders, pixels */
+e_drawname (EObj * eop, int d, int wb, int hb)
 {
 	Trail *tp = &eop->trail[0];
 	char *name = tp->t_obj.o_name;
@@ -4503,17 +4394,17 @@ e_draworbname (EObj *eop, int x, int y)
 
 /* this function just captures the code we were inventing over and over to draw
  * polylines.
+@param xp[];	 working array 
+@param xpsize;	 entries in xp[] 
+@param i;		item we are on: 0..max 
+@param vis;	 is this point visible 
+@param nxp;	number of items in xp[] in use -- next goes in xp[npx] 
+@param max;	largest item number we will draw 
+@param w;		window width -- used to check top wraps 
+@param x, y;	 the point to add to polyline 
  */
 static int
-add_to_polyline (xp, xpsize, i, vis, nxp, max, w, x, y)
-XPoint xp[];	/* working array */
-int xpsize;	/* entries in xp[] */
-int i;		/* item we are on: 0..max */
-int vis;	/* is this point visible */
-int nxp;	/* number of items in xp[] in use -- next goes in xp[npx] */
-int max;	/* largest item number we will draw */
-int w;		/* window width -- used to check top wraps */
-int x, y;	/* the point to add to polyline */
+add_to_polyline (XPoint xp[], int xpsize, int i, int vis, int nxp, int max, int w, int x, int y)
 {
 	int lx = 0, ly = 0;
 	int xwrap = 0;
@@ -4608,9 +4499,7 @@ int x, y;	/* the point to add to polyline */
 
 /* mark the mainmenu location */
 static void
-e_mainmenuloc (np, d, wb, hb)
-Now *np;
-unsigned d, wb, hb;
+e_mainmenuloc (Now * np, unsigned d, unsigned wb, unsigned hb)
 {
 	XSetForeground (XtD, e_olgc, ecolors[HEREC].p);
 	e_drawcross (d, wb, hb, lat, lng, PLUSS);
@@ -4618,9 +4507,7 @@ unsigned d, wb, hb;
 
 /* mark the location of a solar eclipse, if any. */
 static void
-e_soleclipse (np, d, wb, hb)
-Now *np;
-unsigned d, wb, hb;
+e_soleclipse (Now * np, unsigned d, unsigned wb, unsigned hb)
 {
 	Obj *sunp = db_basic (SUN);
 	Obj *moonp = db_basic (MOON);
@@ -4638,13 +4525,13 @@ unsigned d, wb, hb;
  * to the point at which the given height appears at the given altitude, in
  * rads.
  * N.B. beware of negative heights (deorbited ;-))
+@param *np;	refraction circumstances 
+@param height;	satellite elevation, m above mean earth 
+@param alt;	viewing altitude, rads above horizon 
+@param *radp;	great-circle distance from subpoint to viewing circle, rads
  */
 static void
-e_viewrad (np, height, alt, radp)
-Now *np;	/* refraction circumstances */
-double height;	/* satellite elevation, m above mean earth */
-double alt;	/* viewing altitude, rads above horizon */
-double *radp;	/* great-circle distance from subpoint to viewing circle, rads*/
+e_viewrad (Now * np, double height, double alt, double *radp)
 {
 	/* remove effect of refraction from geometry */
 	unrefract (pressure, temp, alt, &alt);
@@ -4660,10 +4547,7 @@ double *radp;	/* great-circle distance from subpoint to viewing circle, rads*/
  * return 0 if ok else -1 if no memory.
  */
 static void
-e_resettrail(eop, np, discard)
-EObj *eop;
-Now *np;
-int discard;
+e_resettrail(EObj * eop, Now * np, int discard)
 {
 	Obj *op = eop->op;
 	Trail *tp = eop->trail;
@@ -4696,10 +4580,7 @@ int discard;
  */
 /* ARGSUSED */
 static int
-e_mktrail (ts, statep, client)
-TrTS ts[];
-TrState *statep;
-XtPointer client;
+e_mktrail (TrTS ts[], TrState * statep, XtPointer client)
 {
 	EObj *eop = &eobjs[(long int)client];
 	Obj *op = eop->op;
@@ -4764,8 +4645,7 @@ XtPointer client;
 /* grow the trails list by one and return the address of the new entry.
  */
 static Trail *
-e_growtrail (eop)
-EObj *eop;
+e_growtrail (EObj * eop)
 {
 	eop->trail = (Trail *) XtRealloc ((char *)eop->trail,
 					    (eop->ntrail+1)*sizeof(Trail));
@@ -4884,8 +4764,7 @@ e_getwxgif()
  * return XImage * if ok else NULL and xe_msg().
  */
 static XImage *
-e_create_xim (w, h)
-int w, h;
+e_create_xim (int w, int h)
 {
 	Display *dsp = XtDisplay(e_da_w);
 	XImage *xip;
@@ -4935,9 +4814,7 @@ int w, h;
 
 /* given a time and location, return 1 if location is in sunlight, else 0 */
 static int
-e_issunlit (np, l, L)
-Now *np;
-double l, L;
+e_issunlit (Now * np, double l, double L)
 {
 	static double last_mjd;
 	static double csslat, ssslat;
@@ -4957,8 +4834,7 @@ double l, L;
 
 /* return 1 if the given wxgifpix is gray, else 0 */
 static int
-e_wxisgray (p)
-int p;
+e_wxisgray (int p)
 {
 	int r = (int)wxxcols[p].red >> 8;
 	int g = (int)wxxcols[p].green >> 8;
@@ -5024,9 +4900,7 @@ e_newwxpm()
  * return 0 if ok, else -1.
  */
 static int
-e_setupwxpm (reload, rebuild)
-int reload;
-int rebuild;
+e_setupwxpm (int reload, int rebuild)
 {
 	static double last_mjd;
 	Now *np = mm_get_now();
@@ -5055,11 +4929,12 @@ int rebuild;
 	return (0);
 }
 
-/* convert lat/long to x/y on www.ssec.wisc.edu/data/comp/latest_cmoll.gif */
+/* convert lat/long to x/y on www.ssec.wisc.edu/data/comp/latest_cmoll.gif 
+@param l, L;		 lat, long, rads, +N, +E 
+@param *xp, *yp;		gif location 
+*/
 static void
-mollweide_llxy (l, L, xp, yp)
-double l, L;		/* lat, long, rads, +N, +E */
-short *xp, *yp;		/* gif location */
+mollweide_llxy (double l, double L, short * xp, short * yp)
 {
 	double tmp;
 
@@ -5074,11 +4949,11 @@ short *xp, *yp;		/* gif location */
 
 /* convert x/y to lat/long on www.ssec.wisc.edu/data/comp/latest_cmoll.gif.
  * return 1 if actually on the earth map, else 0.
+@param x, y;		gif location 
+@param *lp, *Lp;	lat, long, rads, +N, +E 
  */
 static int
-mollweide_xyll (x, y, lp, Lp)
-int x, y;		/* gif location */
-double *lp, *Lp;	/* lat, long, rads, +N, +E */
+mollweide_xyll (int x, int y, double * lp, double * Lp)
 {
 	double fx, fy;
 
@@ -5209,8 +5084,7 @@ loadnei()
 
 /* render deipix and neipix into e_pm */
 static void
-drawei (ww, wh, d, xb, yb)
-unsigned int ww, wh, d, xb, yb;
+drawei (unsigned int ww, unsigned int wh, unsigned int d, unsigned int xb, unsigned int yb)
 {
 	Now *np = mm_get_now();
 	Display *dsp = XtD;

--- a/GUI/xephem/favmenu.c
+++ b/GUI/xephem/favmenu.c
@@ -46,7 +46,7 @@ static void fav_save_cb (Widget w, XtPointer client, XtPointer call);
 static void fav_create (void);
 static void showFavorites (void);
 static void setup1Row (Widget rc_w, int i);
-static void loadFavs ();
+static void loadFavs (char *);
 static void saveFavs (char *filename);
 static void favRmAll(void);
 static void bldExport(void);
@@ -390,9 +390,7 @@ showFavorites()
 
 /* using info from favs[i] create its row in the favories window */
 static void
-setup1Row (rc_w, i)
-Widget rc_w;
-int i;
+setup1Row (Widget rc_w, int i)
 {
 	Widget f_w, on_w, del_w, lbl_w, up_w, dn_w;
 	Arg args[20];
@@ -470,10 +468,7 @@ int i;
  */
 /* ARGSUSED */
 static void
-fav_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "Collection of favorite objects",
@@ -485,10 +480,7 @@ XtPointer call;
 /* callback from the Close PB */
 /* ARGSUSED */
 static void
-fav_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (favshell_w);
 }
@@ -498,10 +490,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-fav_load_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_load_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 
@@ -519,10 +508,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-fav_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024], *fn;
 	char *txt;
@@ -548,10 +534,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-fav_add_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_add_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024];
 	char *txt;
@@ -624,10 +607,7 @@ chg_i()
  */
 /* ARGSUSED */
 static void
-fav_on_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_on_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int wanton = XmToggleButtonGetState (w);
 	int i = (long int)client;
@@ -644,10 +624,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-fav_up_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_up_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i = (long int)client;
 
@@ -665,10 +642,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-fav_dn_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_dn_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i = (long int)client;
 
@@ -686,10 +660,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-fav_del_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fav_del_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* save index */
 	deli = (long int)client;

--- a/GUI/xephem/formats.c
+++ b/GUI/xephem/formats.c
@@ -39,9 +39,7 @@ f_ison()
  * if we don't update the value then mark it as insensitive for feedback.
  */
 void
-f_showit (w, s)
-Widget w;
-char *s;
+f_showit (Widget w, char *s)
 {
 	/* testing is faster than setting */
 	if (XtIsSensitive(w) != !f_scrnoff)
@@ -61,11 +59,7 @@ char *s;
  * see fs_sexa for full formatting details.
  */
 void
-f_sexa (wid, a, w, fracbase)
-Widget wid;
-double a;
-int w;
-int fracbase;
+f_sexa (Widget wid, double a, int w, int fracbase)
 {
 	char out[64];
 
@@ -77,9 +71,7 @@ int fracbase;
 /* print ra, in radians, to widget w in hours according to the precision pref.
  */
 void
-f_ra (w, ra)
-Widget w;
-double ra;
+f_ra (Widget w, double ra)
 {
 	if (pref_get(PREF_DPYPREC) == PREF_LOPREC)
 	    f_sexa (w, radhr(ra), 2, 600);
@@ -90,9 +82,7 @@ double ra;
 /* print ra, in radians, into string out[] in hours according to precision pref.
  */
 void
-fs_ra (out, ra)
-char out[];
-double ra;
+fs_ra (char out[], double ra)
 {
 	if (pref_get(PREF_DPYPREC) == PREF_LOPREC)
 	    fs_sexa (out, radhr(ra), 2, 600);
@@ -104,9 +94,7 @@ double ra;
  * precision preference.
  */
 void
-f_prdec(w, a)
-Widget w;
-double a;
+f_prdec(Widget w, double a)
 {
 	if (pref_get(PREF_DPYPREC) == PREF_LOPREC)
 	    f_sexa (w, raddeg(a), 3, 60);
@@ -118,9 +106,7 @@ double a;
  * precision preference.
  */
 void
-fs_prdec(out, a)
-char out[];
-double a;
+fs_prdec(char out[], double a)
 {
 	if (pref_get(PREF_DPYPREC) == PREF_LOPREC)
 	    fs_sexa (out, raddeg(a), 3, 60);
@@ -130,9 +116,7 @@ double a;
 
 /* print time, t, as hh:mm:ss */
 void
-f_time (w, t)
-Widget w;
-double t;
+f_time (Widget w, double t)
 {
 	range (&t, 24.0);
 #ifdef AVOID_24H
@@ -144,9 +128,7 @@ double t;
 
 /* print time, t, as hh:mm:ss */
 void
-fs_time (out, t)
-char out[];
-double t;
+fs_time (char out[], double t)
 {
 	range (&t, 24.0);
 #ifdef AVOID_24H
@@ -158,9 +140,7 @@ double t;
 
 /* print time, t, as hh:mm to widget w */
 void
-f_mtime (w, t)
-Widget w;
-double t;
+f_mtime (Widget w, double t)
 {
 	range (&t, 24.0);
 #ifdef AVOID_24H
@@ -172,9 +152,7 @@ double t;
 
 /* print time, t, as hh:mm into out[] */
 void
-fs_mtime (out, t)
-char out[];
-double t;
+fs_mtime (char out[], double t)
 {
 	range (&t, 24.0);
 #ifdef AVOID_24H
@@ -186,18 +164,14 @@ double t;
 
 /* print angle, a, in rads, as degrees to widget w in form ddd:mm */
 void
-f_dm_angle(w, a)
-Widget w;
-double a;
+f_dm_angle(Widget w, double a)
 {
 	f_sexa (w, raddeg(a), 3, 60);
 }
 
 /* print angle, a, in rads, as degrees into string out[] in form ddd:mm */
 void
-fs_dm_angle(out, a)
-char out[];
-double a;
+fs_dm_angle(char out[], double a)
 {
 	fs_sexa (out, raddeg(a), 3, 60);
 }
@@ -207,9 +181,7 @@ double a;
  * precision preference.
  */
 void
-f_pangle(w, a)
-Widget w;
-double a;
+f_pangle(Widget w, double a)
 {
 	if (pref_get(PREF_DPYPREC) == PREF_LOPREC)
 	    f_sexa (w, raddeg(a), 3, 60);
@@ -221,9 +193,7 @@ double a;
  * precision preference.
  */
 void
-fs_pangle(out, a)
-char out[];
-double a;
+fs_pangle(char out[], double a)
 {
 	if (pref_get(PREF_DPYPREC) == PREF_LOPREC)
 	    fs_sexa (out, raddeg(a), 3, 60);
@@ -233,18 +203,14 @@ double a;
 
 /* print angle, a, in rads, as degrees to widget w in form dddd:mm:ss */
 void
-f_dms_angle(w, a)
-Widget w;
-double a;
+f_dms_angle(Widget w, double a)
 {
 	f_sexa (w, raddeg(a), 4, 3600);
 }
 
 /* print angle, a, in rads, as degrees into string out[] in form dddd:mm:ss */
 void
-fs_dms_angle(out, a)
-char out[];
-double a;
+fs_dms_angle(char out[], double a)
 {
 	fs_sexa (out, raddeg(a), 4, 3600);
 }
@@ -252,9 +218,7 @@ double a;
 /* print the given modified Julian date, jd, in the preferred format.
  */
 void
-f_date (w, jd)
-Widget w;
-double jd;
+f_date (Widget w, double jd)
 {
 	char out[32];
 	double tmp;
@@ -276,19 +240,14 @@ double jd;
  *   use f_showit() directly.
  */
 void
-f_string (w, s)
-Widget w;
-char *s;
+f_string (Widget w, char *s)
 {
 	field_log (w, 0.0, 0, s);
 	f_showit (w, s);
 }
 
 void
-f_double (w, fmt, f)
-Widget w;
-char *fmt;
-double f;
+f_double (Widget w, char * fmt, double f)
 {
 	char str[80];
 	(void) sprintf (str, fmt, f);
@@ -296,12 +255,11 @@ double f;
 	f_showit (w, str);
 }
 
-/* fill buf() with given timezone name */
+/* fill buf() with given timezone name 
+@param tzpref;     PREF_UTCTZ or PREF_LOCALTZ
+*/
 void
-fs_tz (buf, tzpref, np)
-char buf[];
-int tzpref;	/* PREF_UTCTZ or PREF_LOCALTZ */
-Now *np;
+fs_tz (char buf[], int tzpref, Now * np)
 {
 	if (tzpref == PREF_UTCTZ)
 	    (void) strcpy(buf, "UTC");
@@ -316,9 +274,7 @@ Now *np;
 
 /* fill buf[] with time stamp from np */
 void
-fs_timestamp (np, stamp)
-Now *np;
-char stamp[];
+fs_timestamp (Now * np, char stamp[])
 {
 	double lmjd;
 	char d[32], t[32];
@@ -342,9 +298,7 @@ char stamp[];
  *   because we want the time to always be updated even during movie loops.
  */
 void
-timestamp (np, w)
-Now *np;
-Widget w;
+timestamp (Now * np, Widget w)
 {
 	char stamp[64];
 	char *txtp;

--- a/GUI/xephem/glance.c
+++ b/GUI/xephem/glance.c
@@ -116,9 +116,7 @@ ng_manage ()
 /* commanded from main to update with a new set of circumstances */
 /* ARGSUSED */
 void
-ng_update (np, how_much)
-Now *np;
-int how_much;
+ng_update (Now * np, int how_much)
 {
 	/* only if we're up */
 	if (!ng_ison())
@@ -150,8 +148,7 @@ ng_newres()
 
 /* called to put up or remove the watch cursor.  */
 void
-ng_cursor (c)
-Cursor c;
+ng_cursor (Cursor c)
 {
 	Window win;
 
@@ -401,10 +398,7 @@ ng_create_popup()
 /* callback from the Print PB */
 /* ARGSUSED */
 static void
-ng_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_print_cb (Widget w, XtPointer client, XtPointer call)
 {
         XPSAsk ("Night-at-a-Glance", ng_print);
 }
@@ -412,10 +406,7 @@ XtPointer call;
 /* callback from the One Color TB */
 /* ARGSUSED */
 static void
-ng_1col_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_1col_cb (Widget w, XtPointer client, XtPointer call)
 {
         ng_redraw();
 }
@@ -423,10 +414,7 @@ XtPointer call;
 /* callback from the inputCallback*/
 /* ARGSUSED */
 static void
-ng_da_input_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_da_input_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	Now *np = mm_get_now();
@@ -588,10 +576,7 @@ ng_ps_annotate ()
 /* callback from PB in popup to set XEphem time to punow. */
 /* ARGSUSED */
 static void
-ng_settime_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_settime_cb (Widget w, XtPointer client, XtPointer call)
 {
 	mm_newcaldate (punow.n_mjd);
 }
@@ -599,10 +584,7 @@ XtPointer call;
 /* callback from ngshell_w being popped down. */
 /* ARGSUSED */
 static void
-ng_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (ng_pm) {
 	    XFreePixmap (XtD, ng_pm);
@@ -615,10 +597,7 @@ XtPointer call;
 
 /* called from Close button */
 static void
-ng_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (ngshell_w);
 	/* popping down ngshell_w will do all the real work */
@@ -626,10 +605,7 @@ XtPointer call;
 
 /* called to add graph to movie loop */
 static void
-ng_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (ng_pm, dt_w);
 }
@@ -638,10 +614,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ng_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "This is the night at a glance.",
@@ -654,10 +627,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ng_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ng_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	Display *dsp = XtDisplay(ngda_w);
@@ -725,8 +695,7 @@ ng_redraw()
  * if ep just copy that much, else copy all.
  */
 static void
-ng_refresh(ep)
-XExposeEvent *ep;
+ng_refresh(XExposeEvent * ep)
 {
 	Display *dsp = XtDisplay(ngda_w);
 	Window win = XtWindow (ngda_w);
@@ -781,10 +750,7 @@ ng_init_gcs()
  * N.B. this is just the geometry, we ignore rp->rs_flags
  */
 static void
-rs_x (np, rp, xr, xs)
-Now *np;
-RiseSet *rp;
-int *xr, *xs;
+rs_x (Now * np, RiseSet * rp, int * xr, int * xs)
 {
 	double t;
 
@@ -799,10 +765,7 @@ int *xr, *xs;
  * N.B. do not use this for EARTHSAT, use rs_es().
  */
 static int
-rs_xrs (np, op, xr, xs)
-Now *np;
-Obj *op;
-int *xr, *xs;
+rs_xrs (Now * np, Obj * op, int * xr, int * xs)
 {
 	RiseSet rs;
 	int nowright;
@@ -856,11 +819,7 @@ int *xr, *xs;
  * set xrp to left-most rise, xsp to right-most set.
  */
 static int
-rs_es (np, op, y, xrp, xsp)
-Now *np;
-Obj *op;
-int y;
-int *xrp, *xsp;
+rs_es (Now * np, Obj * op, int y, int * xrp, int * xsp)
 {
 	Display *dsp = XtD;
 	RiseSet rs;

--- a/GUI/xephem/gsc.c
+++ b/GUI/xephem/gsc.c
@@ -123,10 +123,7 @@ static void cacheWriteEntry (GSCRegion *rp, GSCEntry *ep);
  * N.B. cdp and chp must remain valid for GSCFetch().
  */
 int
-GSCSetup (cdp, chp, msg)
-char *cdp;
-char *chp;
-char msg[];
+GSCSetup (char * cdp, char * chp, char msg[])
 {
 	/* set up the new paths and flags */
 	cdpath = cdp;
@@ -182,16 +179,16 @@ char msg[];
  * we return new total number of stars or -1 if real trouble.
  * *spp is only changed if we added any.
  * msg might contain a message regardless of the return value.
+@param ra0;	center RA, rads 
+@param dec0;	center Dec, rads 
+@param fov;	field of view, rads 
+@param fmag;	faintest mag 
+@param **spp;	*spp will be a malloced array of ObjF stars in region 
+@param nspp;	if spp: initial number of ObjF already in *spp 
+@param msg[];	possible return error or status message 
  */
 int
-GSCFetch (ra0, dec0, fov, fmag, spp, nspp, msg)
-double ra0;	/* center RA, rads */
-double dec0;	/* center Dec, rads */
-double fov;	/* field of view, rads */
-double fmag;	/* faintest mag */
-ObjF **spp;	/* *spp will be a malloced array of ObjF stars in region */
-int nspp;	/* if spp: initial number of ObjF already in *spp */
-char msg[];	/* possible return error or status message */
+GSCFetch (double ra0, double dec0, double fov, double fmag, ObjF ** spp, int nspp, char msg[])
 {
 	Request q;
 	GSCArray sa;
@@ -258,9 +255,7 @@ char msg[];	/* possible return error or status message */
  * return 0 if ok else fill lmsg[] and return -1 if trouble.
  */
 static int
-handleRequest (qp, ap)
-Request *qp;
-GSCArray *ap;
+handleRequest (Request * qp, GSCArray * ap)
 {
 	char ids[9537];		/* set when region has already been visited */
 	GSCRegion region;
@@ -328,10 +323,7 @@ GSCArray *ap;
  * if ok return count, else put reason in lmsg and return -1.
  */
 static int
-fetchRegion (rp, qp, ap)
-GSCRegion *rp;
-Request *qp;
-GSCArray *ap;
+fetchRegion (GSCRegion * rp, Request * qp, GSCArray *ap)
 {
 	GSCRegion cr;	/* used for the cache entry */
 
@@ -403,9 +395,7 @@ GSCArray *ap;
 /* return 0 if the given entry is within the given request, else return -1.
  */
 static int
-inFOV (qp, ep)
-Request *qp;
-GSCEntry *ep;
+inFOV (Request * qp, GSCEntry *ep)
 {
 	double cr = qp->sdec*sin(ep->dec) +
 				    qp->cdec*cos(ep->dec)*cos(qp->ra - ep->ra);
@@ -414,9 +404,7 @@ GSCEntry *ep;
 
 /* return 0 if the given entry is at least as bright as the faint limit, else -1 */
 static int
-magOK (qp, ep)
-Request *qp;
-GSCEntry *ep;
+magOK (Request * qp, GSCEntry *ep)
 {
 	return (ep->mag <= qp->mag ? 0 : -1);
 }
@@ -426,10 +414,7 @@ GSCEntry *ep;
  * return 0 if ok, else put reason in lmsg and return -1
  */
 static int
-addOneStar (ap, rp, ep)
-GSCArray *ap;
-GSCRegion *rp;
-GSCEntry *ep;
+addOneStar (GSCArray * ap, GSCRegion * rp, GSCEntry *ep)
 {
 	int sz = sizeof(ObjF);
 	Obj *op;
@@ -472,13 +457,12 @@ GSCEntry *ep;
 }
 
 static int
-mymkdir (path)
-char *path;
+mymkdir (char * path)
 {
 	return (mkdir (expand_home (path), 0755));
 }
 
-
+
 /* code to handle the details of reading the CDROM */
 
 /* index by dec band and get the number of large regions in it and its first
@@ -626,10 +610,7 @@ static SmallRegionTable sm_reg[733] = {
  *   sm_reg_x.tbl, lg_reg_x.tbl and regions.tbl.
  */
 static void
-gscPickRegion (ra, dec, rp)
-double ra;
-double dec;
-GSCRegion *rp;
+gscPickRegion (double ra, double dec, GSCRegion * rp)
 {
 	int decband;	/* which 7.5-degree dec band: 0..11 */
 	int raband;	/* which group of small ra bands */
@@ -714,8 +695,7 @@ GSCRegion *rp;
  * N.B. this code heavily assumes these the GSC FITS files.
  */
 static int
-gscOpenRegion (rp)
-GSCRegion *rp;
+gscOpenRegion (GSCRegion * rp)
 {
 	typedef enum {FINDNAXIS2, FINDEND, SKIPTOBLOCK, FOUNDTABLE} State;
 	char buf[FLL+1];	/* we add EOS */
@@ -782,8 +762,7 @@ GSCRegion *rp;
  * else return -1.
  */
 static int
-gscSimpleFits (fp)
-FILE *fp;
+gscSimpleFits (FILE * fp)
 {
 	static char smpl[31] = "SIMPLE  =                    T";
 	char buf[FLL];
@@ -800,9 +779,7 @@ FILE *fp;
  * else set rp->fp to NULL and full msg with an error message.
  */
 static void
-gscOpenFile (rp, msg)
-GSCRegion *rp;
-char *msg;
+gscOpenFile (GSCRegion * rp, char * msg)
 {
 	char path[1024];
 
@@ -823,9 +800,7 @@ char *msg;
  * decrement rp->nrows as we go and return -1 when it reaches 0, else 0.
  */
 static int
-gscGetNextEntry (rp, ep)
-GSCRegion *rp;
-GSCEntry *ep;
+gscGetNextEntry (GSCRegion * rp, GSCEntry *ep)
 {
 	char buf[16];
 
@@ -890,14 +865,12 @@ GSCEntry *ep;
 /* do whatever cleanup might be required when finished with rp
  */
 static void
-gscCloseRegion (rp)
-GSCRegion *rp;
+gscCloseRegion (GSCRegion * rp)
 {
 	fclose (rp->fp);
 	rp->fp = NULL;
 }
 
-
 /* code to handle the details of the GSC cache files.
  * the files have a short header at the front in ASCII.
  * the stars then follow in a packed binary format.
@@ -923,9 +896,7 @@ GSCRegion *rp;
  * return 0 if ok else return -1.
  */
 static int
-cacheOpenRegion (rp, cp)
-GSCRegion *rp;
-GSCRegion *cp;
+cacheOpenRegion (GSCRegion * rp, GSCRegion * cp)
 {
 	char fullpath[1024];
 
@@ -972,9 +943,7 @@ GSCRegion *cp;
  * decrement rp->nrows as we go and return -1 when it reaches 0, else 0.
  */
 static int
-cacheGetNextEntry (rp, ep)
-GSCRegion *rp;
-GSCEntry *ep;
+cacheGetNextEntry (GSCRegion * rp, GSCEntry * ep)
 {
 	if (rp->nrows <= 0)
 	    return (-1);
@@ -987,8 +956,7 @@ GSCEntry *ep;
 /* do whatever cleanup might be required when finished with rp.
  */
 static void
-cacheCloseRegion (rp)
-GSCRegion *rp;
+cacheCloseRegion (GSCRegion * rp)
 {
 	fclose (rp->fp);
 	rp->fp = NULL;
@@ -999,9 +967,7 @@ GSCRegion *rp;
  * return 0 if ok, else complain to lmsg and return -1.
  */
 static int
-cacheCreateRegion (rp, cp)
-GSCRegion *rp;
-GSCRegion *cp;
+cacheCreateRegion (GSCRegion * rp, GSCRegion * cp)
 {
 	char fullpath[1024];
 
@@ -1042,9 +1008,7 @@ GSCRegion *cp;
 /* write ep to rp->fp.
  */
 static void
-cacheAddEntry (rp, ep)
-GSCRegion *rp;
-GSCEntry *ep;
+cacheAddEntry (GSCRegion * rp, GSCEntry *ep)
 {
 	cacheWriteEntry (rp, ep);
 }
@@ -1052,9 +1016,7 @@ GSCEntry *ep;
 /* build a full cache filename for rp off chpath dir.
  */
 static void
-cacheBuildFilename (fullpath, rp)
-char fullpath[];
-GSCRegion *rp;
+cacheBuildFilename (char fullpath[], GSCRegion * rp)
 {
 	(void) sprintf (fullpath, "%s/%s/%04d.ech", chpath, rp->dir, rp->id);
 }
@@ -1062,9 +1024,7 @@ GSCRegion *rp;
 /* build a full cache dir for rp off chpath dir.
  */
 static void
-cacheBuildDir (fullpath, rp)
-char fullpath[];
-GSCRegion *rp;
+cacheBuildDir (char fullpath[], GSCRegion *rp)
 {
 	(void) sprintf (fullpath, "%s/%s", chpath, rp->dir);
 }
@@ -1073,8 +1033,7 @@ GSCRegion *rp;
  * leave rp->fp positioned at first star.
  */
 static int
-cacheReadHeader (rp)
-GSCRegion *rp;
+cacheReadHeader (GSCRegion * rp)
 {
 	char hdr[128];
 	double v;
@@ -1116,8 +1075,7 @@ GSCRegion *rp;
  * N.B. must be same length every time because we are called to overright.
  */
 static void
-cacheWriteHeader (rp)
-GSCRegion *rp;
+cacheWriteHeader (GSCRegion * rp)
 {
 	char hdr[128];
 	int n;
@@ -1140,9 +1098,7 @@ GSCRegion *rp;
  *  all values stored in big-endian byte order.
  */
 static void
-cacheReadEntry (rp, ep)
-GSCRegion *rp;
-GSCEntry *ep;
+cacheReadEntry (GSCRegion * rp, GSCEntry * ep)
 {
 	FILE *fp = rp->fp;
 	unsigned char buf[2];
@@ -1176,9 +1132,7 @@ GSCEntry *ep;
  *  all values stored in big-endian byte order.
  */
 static void
-cacheWriteEntry (rp, ep)
-GSCRegion *rp;
-GSCEntry *ep;
+cacheWriteEntry (GSCRegion * rp, GSCEntry * ep)
 {
 	FILE *fp = rp->fp;
 	unsigned char buf[2];

--- a/GUI/xephem/helpmenu.c
+++ b/GUI/xephem/helpmenu.c
@@ -50,12 +50,13 @@ static char help_instructions[] =
 
 /* trigger help for the given tag.
  * if fail so and use the deflt provided, if any.
+@param *tag;      tag to look for in help file
+@param *deflt[];  help text to use if tag not found
+@param ndeflt;     number of strings in deflt[]
+
  */
 void
-hlp_dialog (tag, deflt, ndeflt)
-char *tag;	/* tag to look for in help file */
-char *deflt[];	/* help text to use if tag not found */
-int ndeflt;	/* number of strings in deflt[] */
+hlp_dialog (char * tag, char *deflt[], int ndeflt)
 {
 	static char *hurl;
 	static int triedhurl;
@@ -226,10 +227,7 @@ hlp_create ()
 /* called on Close */
 /* ARGSUSED */
 static void
-hlp_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hlp_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (hlp_w);
 }
@@ -237,10 +235,7 @@ XtPointer call;
 /* called when any TB changes */
 /* ARGSUSED */
 static void
-hlp_radio_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hlp_radio_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int set = XmToggleButtonGetState(w);
 	int i;

--- a/GUI/xephem/homeio.c
+++ b/GUI/xephem/homeio.c
@@ -77,9 +77,7 @@ expand_home (char *path)
 /* like fopen() but substitutes HOME if name starts with '~'
  */
 FILE *
-fopenh (name, how)
-char *name;
-char *how;
+fopenh (char * name, char * how)
 {
 	return (fopen (expand_home(name), how));
 }
@@ -153,8 +151,7 @@ openh (char *name, int flags, ...)
  * substitute HOME if name starts with '~'.
  */
 int
-existsh (name)
-char *name;
+existsh (char * name)
 {
 	struct stat s;
 

--- a/GUI/xephem/hznmenu.c
+++ b/GUI/xephem/hznmenu.c
@@ -102,8 +102,7 @@ hznEditingOff()
 
 /* called to put up or remove the watch cursor.  */
 void
-hzn_cursor (c)
-Cursor c;
+hzn_cursor (Cursor c)
 {
 	Window win;
 
@@ -151,8 +150,7 @@ hznProfile (int i, double *altp, double *azp)
 /* given an az, return the horizon altitude, both in rads.
  */
 double
-hznAlt(az)
-double az;
+hznAlt(double az)
 {
 	Profile *pb, *pt;
 	double daz;
@@ -420,10 +418,7 @@ hzn_create()
 /* called from Close */
 /* ARGSUSED */
 static void
-hzn_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (hznshell_w);
 }
@@ -431,10 +426,7 @@ XtPointer call;
 /* called when unmapped for any reason */
 /* ARGSUSED */
 static void
-hzn_unmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_unmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hznEditingOff();
 }
@@ -442,10 +434,7 @@ XtPointer call;
 /* called when edit TB changes */
 /* ARGSUSED */
 static void
-hzn_edit_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_edit_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState(w)) {
 	    sv_hznOn();				/* public service feature */
@@ -456,10 +445,7 @@ XtPointer call;
 /* called from Help */
 /* ARGSUSED */
 static void
-hzn_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_help_cb (Widget w, XtPointer client, XtPointer call)
 {
         static char *msg[] = {"Specify local horizon."};
 
@@ -472,10 +458,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-hzn_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024];
 	char *fn;
@@ -503,10 +486,7 @@ XtPointer call;
 /* Displacement TB callback */
 /* ARGSUSED */
 static void
-hzn_displtb_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_displtb_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hzn_choose (XmToggleButtonGetState (w));
 }
@@ -514,10 +494,7 @@ XtPointer call;
 /* Displacement TF callback */
 /* ARGSUSED */
 static void
-hzn_displtf_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_displtf_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hzn_choose (1);
 }
@@ -525,10 +502,7 @@ XtPointer call;
 /* File TB callback */
 /* ARGSUSED */
 static void
-hzn_filetb_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_filetb_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hzn_choose (!XmToggleButtonGetState (w));
 }
@@ -536,10 +510,7 @@ XtPointer call;
 /* File TF callback */
 /* ARGSUSED */
 static void
-hzn_filetf_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_filetf_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hzn_choose (0);
 }
@@ -549,10 +520,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-hzn_chsfn_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+hzn_chsfn_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 
@@ -590,8 +558,7 @@ hzn_radio (int choose_displ)
  * control the Tbs as well as do the work.
  */
 static void
-hzn_choose (choose_displ)
-int choose_displ;
+hzn_choose (int choose_displ)
 {
 	/* do the work */
 	if (choose_displ)

--- a/GUI/xephem/imregmenu.c
+++ b/GUI/xephem/imregmenu.c
@@ -150,8 +150,7 @@ ir_setstar (double ix, double iy)
 
 /* called to put up or remove the watch cursor.  */
 void
-ir_cursor (c)
-Cursor c;
+ir_cursor (Cursor c)
 {
 	Window win;
 
@@ -292,10 +291,7 @@ ir_create()
 /* called from Close */
 /* ARGSUSED */
 static void
-ir_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ir_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (irshell_w);
 }
@@ -303,10 +299,7 @@ XtPointer call;
 /* called from Help */
 /* ARGSUSED */
 static void
-ir_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ir_help_cb (Widget w, XtPointer client, XtPointer call)
 {
         static char *msg[] = {"Define reference stars then each additional."};
 

--- a/GUI/xephem/jupmenu.c
+++ b/GUI/xephem/jupmenu.c
@@ -183,9 +183,7 @@ jm_manage ()
  * don't bother if it doesn't exist or is unmanaged now or no one is logging.
  */
 void
-jm_update (np, how_much)
-Now *np;
-int how_much;
+jm_update (Now * np, int how_much)
 {
 	static char fmt[] = "%7.3f";
 	Obj *eop = db_basic (SUN);
@@ -258,8 +256,7 @@ jm_newres()
  */
 /* ARGSUSED */
 void
-jm_newdb (appended)
-int appended;
+jm_newdb (int appended)
 {
 	if (skybkg)
 	    jm_update (mm_get_now(), 1);
@@ -274,10 +271,10 @@ jm_ison()
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 void
-jm_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+jm_selection_mode (int whether)
 {
 	if (whether)
 	    jm_selecting++;
@@ -292,8 +289,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 
 /* called to put up or remove the watch cursor.  */
 void
-jm_cursor (c)
-Cursor c;
+jm_cursor (Cursor c)
 {
 	Window win;
 
@@ -991,10 +987,10 @@ jm_create_tvform_w()
 
 /* go through all the buttons pickable for plotting and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 static void
-jm_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+jm_set_buttons (int whether)
 {
 	int i, j;
 
@@ -1010,10 +1006,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 /* callback when the ENTER key is typed on the GRS Long TF */
 /* ARGSUSED */
 static void
-jm_grsl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_grsl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	jm_update (mm_get_now(), 1);
 }
@@ -1021,10 +1014,7 @@ XtPointer call;
 /* callback when the Close button is activated on the stats menu */
 /* ARGSUSED */
 static void
-jm_sstats_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_sstats_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (jsform_w);
 }
@@ -1032,10 +1022,7 @@ XtPointer call;
 /* callback when the More Info button is activated */
 /* ARGSUSED */
 static void
-jm_sstats_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_sstats_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (jsform_w);
 	jm_set_buttons(jm_selecting);
@@ -1045,10 +1032,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_cpdmapping_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_cpdmapping_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtSetSensitive (tel_w, telIsOn());
 }
@@ -1059,10 +1043,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_option_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_option_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (client) {
 	    int *flagp = (int *)client;
@@ -1085,10 +1066,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_scale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_scale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	jm_update (mm_get_now(), 1);
 }
@@ -1097,10 +1075,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (jm_selecting) {
 	    char *name;
@@ -1113,10 +1088,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jt_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jt_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1171,10 +1143,7 @@ XtPointer call;
 /* called whenever the topview scene is mapped. */
 /* ARGSUSED */
 static void
-jt_map_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+jt_map_cb (Widget w, XtPointer client, XtPointer call)
 {
 	jt_track_size();
 }
@@ -1226,10 +1195,7 @@ jt_track_size()
 /* callback when topview dialog is unmapped */
 /* ARGSUSED */
 static void
-jt_unmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jt_unmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (topview_w, False, True);
 }
@@ -1237,10 +1203,7 @@ XtPointer call;
 /* callback when main shell is popped down */
 /* ARGSUSED */
 static void
-jm_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (jsform_w);
 	XtUnmanageChild (jtform_w);
@@ -1275,10 +1238,7 @@ XtPointer call;
 /* callback from the main Close button */
 /* ARGSUSED */
 static void
-jm_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do all the work */
 	XtPopdown (jupshell_w);
@@ -1287,10 +1247,7 @@ XtPointer call;
 /* callback to add scene to the movie loop */
 /* ARGSUSED */
 static void
-jm_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (jm_pm, dt_w);
 }
@@ -1299,10 +1256,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_anim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_anim_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* best effect if turn off worrying about the sky background */
 	skybkg = 0;
@@ -1315,10 +1269,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1376,10 +1327,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_da_input_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_da_input_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	ScreenObj *sop;
@@ -1448,9 +1396,7 @@ jm_create_popup()
 
 /* put up a popup at ev with info about sop */
 static void
-jm_fill_popup (sop, justname)
-ScreenObj *sop;
-int justname;
+jm_fill_popup (ScreenObj * sop, int justname)
 {
 	char *name;
 	double ra, dec, mag;
@@ -1488,10 +1434,7 @@ int justname;
  */
 /* ARGSUSED */
 static void
-jm_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This is a simple schematic depiction of Jupiter and its moons.",
@@ -1505,10 +1448,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1517,10 +1457,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-jm_goto_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_goto_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj *op = db_basic (JUPITER);
 	telGoto (op);
@@ -1529,10 +1466,7 @@ XtPointer call;
 /* add one entry to the given global screenobj array.
  */
 static void
-add_screenobj (soidx, op, x, y)
-SOIdx soidx;
-Obj *op;
-int x, y;
+add_screenobj (SOIdx soidx, Obj* op, int x, int y)
 {
 	char *mem = (char *) screenobj[soidx];
 	int nmem = nscreenobj[soidx];
@@ -1559,8 +1493,7 @@ int x, y;
 
 /* reclaim any existing screenobj entries from the given collection */
 static void
-reset_screenobj(soidx)
-SOIdx soidx;
+reset_screenobj(SOIdx soidx)
 {
 	if (screenobj[soidx]) {
 	    free ((char *)screenobj[soidx]);
@@ -1573,9 +1506,7 @@ SOIdx soidx;
  * if found return the ScreenObj *, else NULL.
  */
 static ScreenObj *
-close_screenobj (soidx, x, y)
-SOIdx soidx;
-int x, y;
+close_screenobj (SOIdx soidx, int x, int y)
 {
 	ScreenObj *scop = screenobj[soidx];
 	ScreenObj *minsop = NULL;
@@ -1601,10 +1532,7 @@ int x, y;
  */
 /* ARGSUSED */
 static void
-jm_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+jm_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XPSAsk ("Jupiter", jm_print);
 }
@@ -1656,8 +1584,7 @@ jm_print ()
 }
 
 static void
-jm_ps_annotate (np)
-Now *np;
+jm_ps_annotate (Now * np)
 {
 	int ctrx = (int)(8.5*72/2);
 	Obj *eop = db_basic (SUN);
@@ -1883,8 +1810,7 @@ Now *np;
  * return 0 if ok else -1.
  */
 static int
-jm_getgif(dsp)
-Display *dsp;
+jm_getgif(Display * dsp)
 {
 	unsigned char *gif;
 	int ngif;
@@ -1941,13 +1867,13 @@ Display *dsp;
  * rotation.
  * factoids: default orientation is E on right, S on top. So, GRS moves from
  *   right to left. Spot is in S hemisphere. CML increases with time.
+@param *dsp;		 Display 
+@param win;		 drawable 
+@param lx, ty, sz;		 left x, top y, size 
+@param grs;		 angle from center to grs, rads 
  */
 static void
-jm_fimage (dsp, win, lx, ty, sz, grs)
-Display *dsp;		/* Display */
-Drawable win;		/* drawable */
-int lx, ty, sz;		/* left x, top y, size */
-double grs;		/* angle from center to grs, rads */
+jm_fimage (Display * dsp, Drawable win, int lx, int ty, int sz, double grs)
 {
 	Obj *jop = db_basic (JUPITER);
 	Obj *sop = db_basic (SUN);
@@ -2034,13 +1960,13 @@ double grs;		/* angle from center to grs, rads */
 
 /* fill win with top image of Jupiter at the given location, size and
  * rotation.
+@param *dsp;		Display 
+@param win;		drawable 
+@param lx, ty, sz;		left x, top y, size 
+@param grs;		angle from center to grs, rads 
  */
 static void
-jm_timage (dsp, win, lx, ty, sz, grs)
-Display *dsp;		/* Display */
-Drawable win;		/* drawable */
-int lx, ty, sz;		/* left x, top y, size */
-double grs;		/* angle from center to grs, rads */
+jm_timage (Display * dsp, Drawable win, int lx, int ty, int sz, double grs)
 {
 	Obj *jop = db_basic (JUPITER);
 	XImage *xip;
@@ -2129,12 +2055,7 @@ double grs;		/* angle from center to grs, rads */
  *     +md[].z: in front, jup radii
  */
 static void
-jm_draw_map (w, jop, jupsize, cmlII, md)
-Widget w;
-Obj *jop;
-double jupsize;
-double cmlII;
-MoonData md[J_NMOONS];
+jm_draw_map (Widget w, Obj * jop, double jupsize, double cmlII, MoonData md[J_NMOONS])
 {
 	Display *dsp = XtDisplay(w);
 	Window win;
@@ -2429,14 +2350,7 @@ make_gcs ()
  * with is in a bounding box tw x th.
  */
 static void
-j_calibline (dsp, win, gc, xc, yc, tag, tw, th, l)
-Display *dsp;
-Drawable win;
-GC gc;
-int xc, yc;
-char *tag;
-int tw, th;
-int l;
+j_calibline (Display * dsp, Drawable win, GC gc, int xc, int yc, char * tag, int tw, int th, int l)
 {
 	int lx = xc - l/2;
 	int rx = lx + l;
@@ -2452,16 +2366,16 @@ int l;
  * save objects and screen locs in the global screenobj array for picking.
  * this is used to draw the backgrounds for the planet closeups.
  * Based on work by: Dan Bruton <WDB3926@acs.tamu.edu>
+@param win;		window to draw on 
+@param w, h;		window size 
+@param fmag;		faintest magnitude to display 
+@param ra0, dec0;	center of patch, rads 
+@param scale;		rads per pixel 
+@param rad;		maximum radius to draw away from ra0/dec0, rads 
+@param fliptb, fliplr;	flip direction; default is S up E right 
  */
 static void
-sky_background (win, w, h, fmag, ra0,dec0,scale,rad,fliptb,fliplr)
-Drawable win;		/* window to draw on */
-unsigned w, h;		/* window size */
-int fmag;		/* faintest magnitude to display */
-double ra0, dec0;	/* center of patch, rads */
-double scale;		/* rads per pixel */
-double rad;		/* maximum radius to draw away from ra0/dec0, rads */
-int fliptb, fliplr;	/* flip direction; default is S up E right */
+sky_background (Drawable win, unsigned w, unsigned h, int fmag, double ra0,double dec0,double scale,double rad,int fliptb,int fliplr)
 {
 	static int before;
 	double cdec0 = cos(dec0);
@@ -2526,8 +2440,7 @@ int fliptb, fliplr;	/* flip direction; default is S up E right */
  * already close enough.
  */
 static void
-jm_loadfs (ra, dec)
-double ra, dec;
+jm_loadfs (double ra, double dec)
 {
 	Now *np = mm_get_now();
 

--- a/GUI/xephem/listmenu.c
+++ b/GUI/xephem/listmenu.c
@@ -102,8 +102,7 @@ lst_manage ()
  * selected to inform us that that button is to be included in a listing.
  */
 void
-lst_selection (name)
-char *name;
+lst_selection (char * name)
 {
 	if (!isUp(lstshell_w) || !XmToggleButtonGetState(select_w))
 	    return;
@@ -115,9 +114,7 @@ char *name;
  * if we are potentially interested.
  */
 void
-lst_log (name, str)
-char *name;
-char *str;
+lst_log (char * name, char * str)
 {
 	if (listing_ison()) {
 	    LstFld *lp;
@@ -166,8 +163,7 @@ listing_ison()
 
 /* called to put up or remove the watch cursor.  */
 void
-lst_cursor (c)
-Cursor c;
+lst_cursor (Cursor c)
 {
 	Window win;
 
@@ -184,8 +180,7 @@ Cursor c;
  * what fields to list.
  */
 static void
-lst_select(whether)
-int whether;
+lst_select(int whether)
 {
 	all_selection_mode(whether);
 }
@@ -426,10 +421,7 @@ lst_create_shell()
  */
 /* ARGSUSED */
 static void
-lst_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+lst_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *t = (XmToggleButtonCallbackStruct *) call;
 	Options op = (Options) client;
@@ -477,10 +469,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-lst_loadcfg_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+lst_loadcfg_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024];
 	FILE *fp;
@@ -529,10 +518,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-lst_savecfg_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+lst_savecfg_cb (Widget w, XtPointer client, XtPointer call)
 {
 	FILE *fp;
 	char buf[1024], *txt;
@@ -580,10 +566,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-lst_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+lst_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (lstshell_w);
 }
@@ -592,10 +575,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-lst_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+lst_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Select fields to become each column of a listing, then run xephem. Each step",
@@ -610,10 +590,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-lst_undo_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+lst_undo_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (nlstflds > 0)
 	    XtUnmanageChild (lstflds[--nlstflds].l_w);
@@ -719,10 +696,10 @@ lst_try_turn_on()
 
 /* turn on listing facility.
  * establish a file to use (and thereby set lst_fp, the "listing-is-on" flag).
+@param *how;	fopen how argument
  */
 static void
-lst_turn_on (how)
-char *how;	/* fopen how argument */
+lst_turn_on (char * how)
 {
 	char *txt = XmTextFieldGetString (filename_w);
 	char pn[1024];

--- a/GUI/xephem/mainmenu.c
+++ b/GUI/xephem/mainmenu.c
@@ -390,8 +390,7 @@ static Pixmap empty_pm;		/* empty pixmap */
  * create and manage all the widgets as children of the mainrc.
  */
 void
-mm_create (mainrc)
-Widget mainrc;
+mm_create (Widget mainrc)
 {
 	/* create the main form */
 	splashMsg ("Building main form\n");
@@ -458,10 +457,7 @@ mm_external ()
  */
 /* ARGSUSED */
 void
-mm_go_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+mm_go_cb (Widget w, XtPointer client, XtPointer call)
 {
 	mm_gostop ((long int)client);
 }
@@ -470,8 +466,7 @@ XtPointer call;
  * newmjd is the new UT date/time as a modifed Julian date.
  */
 void
-mm_newcaldate (newmjd)
-double newmjd;
+mm_newcaldate (double newmjd)
 {
 	mjd = newmjd;
 	set_t0 (&now);
@@ -487,10 +482,10 @@ double newmjd;
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 void
-mm_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+mm_selection_mode (int whether)
 {
 	if (whether)
 	    mm_selecting++;
@@ -504,8 +499,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 
 /* set and save the displayed site name */
 void
-mm_sitename (name)
-char *name;
+mm_sitename (char * name)
 {
 	setXRes (snres, name);
 	if (msitename)
@@ -519,11 +513,10 @@ char *name;
 /* called to set new lat/long Now.
  * TZ, TZName and Sitename get something generic.
  * if update we do a full update, else just set NEW CICUMSTANCES.
+@param l, L;	 lat, long 
  */
 void
-mm_setll (l, L, update)
-double l, L;	/* lat, long */
-int update;
+mm_setll (double l, double L, int update)
 {
 	int hr;
 
@@ -554,9 +547,7 @@ int update;
  * if update we do a full update, else just set NEW CICUMSTANCES.
  */
 void
-mm_setsite (sp, update)
-Site *sp;
-int update;
+mm_setsite (Site * sp, int update)
 {
 	static char envbuf[64]; /* putenv() wants stable string */
 
@@ -594,8 +585,7 @@ mm_getsite ()
 /* set the current epoch. this is used by sky fits to match the EQUINOX field.
  */
 void
-mm_setepoch (yr)
-double yr;
+mm_setepoch (double yr)
 {
 	double newepoch;
 
@@ -612,8 +602,7 @@ double yr;
 
 /* return mjed (Modified Julian Date in ET scale) from mjd (UT scale)
  */
-double mm_mjed (np)
-Now *np;
+double mm_mjed (Now * np)
 {
 	return (np->n_mjd + DeltaT/86400.0);	/* do NOT just use mjd macro! */
 }
@@ -629,10 +618,10 @@ mm_get_now()
  * if a movie is currently running, we stop it, period.
  * then if stepsz != 0 we start one by set movie=1, mspause=0, nstep=MANYSTEPS,
  *   tm_inc=stepsz and do about what the Go button does.
+@param stepsz;	step size, hours 
  */
 void
-mm_movie (stepsz)
-double stepsz;	/* step size, hours */
+mm_movie (double stepsz)
 {
 	/* stop any current external control */
 	ext_stop();
@@ -677,8 +666,7 @@ double stepsz;	/* step size, hours */
  * if how_much then redraw all fields, else just redo the graphics.
  */
 void
-redraw_screen (how_much)
-int how_much;
+redraw_screen (int how_much)
 {
 	watch_cursor(1);
 
@@ -830,8 +818,7 @@ create_pixmaps()
 }
 
 static void
-create_main_form(mainrc)
-Widget mainrc;
+create_main_form(Widget mainrc)
 {
 	Widget mrc_w, f_w;
 	Widget ulfr_w, urfr_w, llfr_w, lrfr_w;
@@ -937,15 +924,11 @@ Widget mainrc;
 	XtManageChild (go_w);
 }
 
-/* build the given Fields in a column */
+/* build the given Fields in a column 
+@param p_w;	 parent 
+*/
 static void
-make_prompts (p_w, pc, title, tip, fp, nfp)
-Widget p_w;	/* parent */
-int pc;
-char *title;
-char *tip;
-Field *fp;
-int nfp;
+make_prompts (Widget p_w, int pc, char * title, char * tip, Field * fp, int nfp)
 {
 	Widget f_w;
 	Widget l_w, b_w;
@@ -1168,8 +1151,7 @@ int nfp;
  * We do some error checking.
  */
 static Widget
-fw(fid)
-int fid;
+fw(int fid)
 {
 	Field *fp = NULL;
 
@@ -1184,8 +1166,7 @@ int fid;
  * should appear to look like buttons or just flat labels.
  */
 static void
-mm_set_buttons (whether)
-int whether;
+mm_set_buttons (int whether)
 {
 	Field *fp;
 
@@ -1211,10 +1192,7 @@ int whether;
  */
 /* ARGSUSED */
 static void
-mm_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+mm_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Field *fp = (Field *)client;
 
@@ -1232,10 +1210,7 @@ XtPointer call;
 /* called when user wants XEphem time to stay in sync with computer */
 /* ARGSUSED */
 static void
-keepnow_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+keepnow_cb (Widget w, XtPointer client, XtPointer call)
 {
 	mm_startrt();
 }
@@ -1309,8 +1284,7 @@ mm_initres()
 /* set up those prompts that use the alternates.
  */
 static void
-mm_set_alt_prompts(fp)
-Field *fp;
+mm_set_alt_prompts(Field * fp)
 {
 	switch (fp->id) {
 	case UD_FID:
@@ -1333,9 +1307,7 @@ Field *fp;
  */
 /* ARGSUSED */
 static void
-mm_timer_cb (client, id)
-XtPointer client;
-XtIntervalId *id;
+mm_timer_cb (XtPointer client, XtIntervalId * id)
 {
 	mm_interval_id = 0; 
 	mm_go(0);
@@ -1377,10 +1349,7 @@ mm_stop()
  */
 /* ARGSUSED */
 static void
-mm_step_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+mm_step_cb (Widget w, XtPointer client, XtPointer call)
 {
 	StepOption *sop = (StepOption *)client;
 
@@ -1399,11 +1368,7 @@ XtPointer call;
  * see mm_gostop() for meaning of arg.
  */
 static void
-mm_go_action (w, e, p, n)
-Widget w;
-XEvent *e;
-String *p;
-Cardinal *n;
+mm_go_action (Widget w, XEvent * e, String * p, Cardinal * n)
 {
 	/* assert */
 	if (!(n && *n && p)) {
@@ -1423,8 +1388,7 @@ Cardinal *n;
  * bring up pm if running fast and not a crazy number of steps.
  */
 static void
-mm_gostop(dir)
-int dir;
+mm_gostop(int dir)
 {
 	if (mm_interval_id) {
 	    mm_stop();
@@ -1447,8 +1411,7 @@ int dir;
  * dir is number of steps to go +step (+) or -step (-), or 0 to just GO.
  */
 static void
-mm_go(dir)
-int dir;
+mm_go(int dir)
 {
 	int srchdone;
 	int drawall;
@@ -1528,8 +1491,7 @@ int dir;
  * as coded in mm_step_option and possibly tminc.
  */
 static void
-mm_step_now(reverse)
-int reverse;
+mm_step_now(int reverse)
 {
 #define	RSACC	(30./3600./24.)	/* nominal rise/set accuracy, days */
 #define	BADRS	(RS_ERROR|RS_CIRCUMPOLAR|RS_NEVERUP)
@@ -1832,8 +1794,7 @@ print_idle()
 }
 
 static void
-print_running(reverse)
-int reverse;
+print_running(int reverse)
 {
 	if (reverse)
 	    print_status ("Running in reverse... press Stop to stop.");
@@ -1850,8 +1811,7 @@ print_extrunning()
 }
 
 static void
-print_status (s)
-char *s;
+print_status (char * s)
 {
 	static char *last_s;
 
@@ -1895,9 +1855,7 @@ print_mspause()
  * to update all related fields.
  */
 static int
-chg_fld (bp, fp)
-char *bp;
-Field *fp;
+chg_fld (char * bp, Field * fp)
 {
 	int new = 0;
 	double tmp;
@@ -2131,10 +2089,7 @@ Field *fp;
  */
 /* ARGSUSED */
 static void
-prompt_ok_cb (w, client, call)
-Widget w;	/* PromptDialog "widget" */
-XtPointer client;
-XtPointer call;
+prompt_ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmSelectionBoxCallbackStruct *s = (XmSelectionBoxCallbackStruct *)call;
 	Field *fp;
@@ -2181,8 +2136,7 @@ XtPointer call;
  * put up a special one for STPSZ_FID and SITE_FID.
  */
 static void
-prompt (fp)
-Field *fp;
+prompt (Field * fp)
 {
 	static Widget prompt_w, steps_w;
 	Widget w, aw;
@@ -2294,8 +2248,7 @@ Field *fp;
 }
 
 static Widget
-create_prompt_w(wp)
-Widget *wp;
+create_prompt_w(Widget * wp)
 {
 	XmString title;
 	Widget prompt_w;
@@ -2353,8 +2306,7 @@ Widget *wp;
  * N.B. continue to support RTC and rtc as code strings for compatability.
  */
 static void
-mm_set_step_code (bp)
-char *bp;
+mm_set_step_code (char * bp)
 {
 	int i;
 
@@ -2409,8 +2361,7 @@ mm_pms()
  * print in a nice order, based on the field locations, as much as possible.
  */
 static void
-mm_now (all)
-int all;
+mm_now (int all)
 {
 	double lmjd = mjd - tz/24.0;
 	double jd = mjd + MJD0;
@@ -2547,8 +2498,7 @@ mm_twilight ()
 }
 
 static void
-mm_newcir (y)
-int y;
+mm_newcir (int y)
 {
 	static int flag;	/* 0:erase/stop 1:draw/pause 2:erase/pause */
 
@@ -2569,9 +2519,7 @@ int y;
  */
 /* ARGSUSED */
 static void
-mm_newcir_cb (client, id)
-XtPointer client;
-XtIntervalId *id;
+mm_newcir_cb (XtPointer client, XtIntervalId * id)
 {
 	int *flag = (int *)client;
 	Pixel p;
@@ -2664,10 +2612,7 @@ ext_readnext()
 /* called when the Ok button is hit in the external file input prompt */
 /* ARGSUSED */
 static void
-ext_ok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ext_ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *name;
 
@@ -2716,10 +2661,7 @@ ext_stop()
 /* called when the Help button is hit in the external file input prompt */
 /* ARGSUSED */
 static void
-ext_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ext_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 static char *hlp[] = {
 "XEphem runs from entries in this file.",

--- a/GUI/xephem/marsmenu.c
+++ b/GUI/xephem/marsmenu.c
@@ -252,9 +252,7 @@ mars_manage ()
 
 /* commanded from main to update with a new set of circumstances */
 void
-mars_update (np, how_much)
-Now *np;
-int how_much;
+mars_update (Now * np, int how_much)
 {
 	if (!mshell_w)
 	    return;
@@ -291,10 +289,10 @@ mars_ison()
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 void
-mars_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+mars_selection_mode (int whether)
 {
 	if (whether)
 	    m_selecting++;
@@ -310,8 +308,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 
 /* called to put up or remove the watch cursor.  */
 void
-mars_cursor (c)
-Cursor c;
+mars_cursor (Cursor c)
 {
 	Window win;
 
@@ -1089,10 +1086,10 @@ m_create_mfform()
 
 /* go through all the buttons pickable for plotting and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 static void
-m_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+m_set_buttons (int whether)
 {
 	buttonAsButton (cml_w, whether);
 	buttonAsButton (slt_w, whether);
@@ -1101,10 +1098,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 /* callback when an item is de/selected in the feature list */
 /* ARGSUSED */
 static void
-m_list_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_list_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmListCallbackStruct *lp = (XmListCallbackStruct *)call;
 
@@ -1118,10 +1112,7 @@ XtPointer call;
 /* callback from the Moons button */
 /* ARGSUSED */
 static void
-m_moons_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_moons_cb (Widget w, XtPointer client, XtPointer call)
 {
 	marsm_manage();
 }
@@ -1129,10 +1120,7 @@ XtPointer call;
 /* callback from the Close button on the stats menu */
 /* ARGSUSED */
 static void
-m_mstats_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_mstats_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (msform_w);
 }
@@ -1140,10 +1128,7 @@ XtPointer call;
 /* callback when want stats menu up */
 /* ARGSUSED */
 static void
-m_mstats_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_mstats_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (msform_w);
 	m_set_buttons(m_selecting);
@@ -1154,10 +1139,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_features_ctrl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_features_ctrl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	MFSel *mfsp;
 
@@ -1199,10 +1181,7 @@ XtPointer call;
 /* callback when want features dialog up */
 /* ARGSUSED */
 static void
-m_features_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_features_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (mfform_w);
 }
@@ -1212,10 +1191,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_feasel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_feasel_cb (Widget w, XtPointer client, XtPointer call)
 {
 	MFSel *mfsp = (MFSel *) client;
 	mfsp->set = XmToggleButtonGetState(w);
@@ -1224,10 +1200,7 @@ XtPointer call;
 /* callback from the Print PB */
 /* ARGSUSED */
 static void
-m_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_print_cb (Widget w, XtPointer client, XtPointer call)
 {
         XPSAsk ("Mars View", m_print);
 }
@@ -1343,10 +1316,7 @@ m_ps_annotate ()
  */
 /* ARGSUSED */
 static void
-m_selection_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_selection_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (m_selecting) {
 	    char *name;
@@ -1358,10 +1328,7 @@ XtPointer call;
 /* callback from the CML scale */
 /* ARGSUSED */
 static void
-m_cml_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_cml_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScaleCallbackStruct *sp = (XmScaleCallbackStruct *)call;
 	int v = sp->value;
@@ -1375,10 +1342,7 @@ XtPointer call;
 /* callback from the SLT scale */
 /* ARGSUSED */
 static void
-m_slt_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_slt_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScaleCallbackStruct *sp = (XmScaleCallbackStruct *)call;
 	int v = sp->value;
@@ -1392,10 +1356,7 @@ XtPointer call;
 /* callback from the Seeing scale */
 /* ARGSUSED */
 static void
-m_see_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_see_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScaleCallbackStruct *sp = (XmScaleCallbackStruct *)call;
 	char str[32];
@@ -1412,10 +1373,7 @@ XtPointer call;
 /* callback from the Apply PB */
 /* ARGSUSED */
 static void
-m_apply_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_apply_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int v;
 
@@ -1441,10 +1399,7 @@ XtPointer call;
 /* callback from the Point PB */
 /* ARGSUSED */
 static void
-m_aim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_aim_cb (Widget w, XtPointer client, XtPointer call)
 {
 	m_setnewpos (pu_l, pu_L);
 }
@@ -1475,10 +1430,7 @@ m_setnewpos (double l, double L)
  */
 /* ARGSUSED */
 static void
-m_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (msform_w);
 	XtUnmanageChild (mfform_w);
@@ -1489,10 +1441,7 @@ XtPointer call;
 
 /* called from Close button */
 static void
-m_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (mshell_w);
 	/* popdown will do all the real work */
@@ -1500,10 +1449,7 @@ XtPointer call;
 
 /* called to add scene to the movie loop */
 static void
-m_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (m_pm, dt_w);
 }
@@ -1513,10 +1459,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_option_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_option_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Option opt = (Option)client;
 	int set;
@@ -1578,10 +1521,7 @@ swap_colors()
  */
 /* ARGSUSED */
 static void
-m_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "This is a map of Mars.",
@@ -1595,10 +1535,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1631,10 +1568,7 @@ m_setsize()
  */
 /* ARGSUSED */
 static void
-m_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	XExposeEvent *e = &c->event->xexpose;
@@ -1674,8 +1608,7 @@ XtPointer call;
  * leave glass_xim NULL if trouble.
  */
 static void
-makeGlassImage (dsp)
-Display *dsp;
+makeGlassImage (Display * dsp)
 {
 	int nbytes = (GLASSSZ*GLASSMAG+7) * (GLASSSZ*GLASSMAG+7) * mbpp/8;
 	char *glasspix = (char *) malloc (nbytes);
@@ -1707,9 +1640,7 @@ Display *dsp;
 
 /* make glassGC */
 static void
-makeGlassGC (dsp, win)
-Display *dsp;
-Window win;
+makeGlassGC (Display * dsp, Window win)
 {
 	XGCValues gcv;
 	unsigned int gcm;
@@ -1728,8 +1659,7 @@ Window win;
  * xc,yc. take care at the edges (m_xim is winsz x winsz)
  */
 static void
-fillGlass (xc, yc)
-int xc, yc;
+fillGlass (int xc, int yc)
 {
 	int sx, sy;	/* coords in m_xim */
 	int gx, gy;	/* coords in glass_xim */
@@ -1757,13 +1687,11 @@ int xc, yc;
 
 /* handle the operation of the magnifying glass.
  * this is called whenever there is left button activity over the image.
+@param b1p, m1, b1r;	button/motion state 
+@param wx, wy;		window coords of cursor 
  */
 static void
-doGlass (dsp, win, b1p, m1, b1r, wx, wy)
-Display *dsp;
-Window win;
-int b1p, m1, b1r;	/* button/motion state */
-int wx, wy;		/* window coords of cursor */
+doGlass (Display * dsp, Window win, int b1p, int m1, int b1r, int wx, int wy)
 {
 	static int lastwx, lastwy;
 	int rx, ry, rw, rh;		/* region */
@@ -1869,11 +1797,7 @@ int wx, wy;		/* window coords of cursor */
 
 /* event handler from all Button events on the mda_w */
 static void
-m_pointer_eh (w, client, ev, continue_to_dispatch)
-Widget w;
-XtPointer client;
-XEvent *ev;
-Boolean *continue_to_dispatch;
+m_pointer_eh (Widget w, XtPointer client, XEvent * ev, Boolean * continue_to_dispatch)
 {
 	Display *dsp = ev->xany.display;
 	Window win = ev->xany.window;
@@ -2020,8 +1944,7 @@ m_setselected()
  * this does the first step if desired, then always the next 2.
  */
 static void
-m_redraw(newim)
-int newim;
+m_redraw(int newim)
 {
 	watch_cursor (1);
 
@@ -2038,8 +1961,7 @@ int newim;
  * if ep just copy that much, else copy all.
  */
 static void
-m_refresh(ep)
-XExposeEvent *ep;
+m_refresh(XExposeEvent *ep)
 {
 	Display *dsp = XtDisplay(mda_w);
 	Window win = XtWindow (mda_w);
@@ -2217,8 +2139,7 @@ m_ano (double *latp, double *lngp, int *xp, int *yp, int w2x, int arg)
 
 /* discard trailing whitespace in name IN PLACE */
 static void
-noTrWhite (name)
-char *name;
+noTrWhite (char * name)
 {
 	int l;
 
@@ -2232,8 +2153,7 @@ char *name;
  * return index into mfsa.
  */
 static int
-findMFSel (type)
-char *type;
+findMFSel (char * type)
 {
 	MFSel *mfsp;
 
@@ -2680,9 +2600,7 @@ mxim_setup ()
  * N.B. it is up to the caller to deal wth flipping.
  */
 static int
-xy2ll (x, y, lp, Lp)
-int x, y;
-double *lp, *Lp;
+xy2ll (int x, int y, double * lp, double * Lp)
 {
 	double R = sqrt ((double)(x*x + y*y));
 	double a;
@@ -2711,9 +2629,7 @@ double *lp, *Lp;
  * N.B. it is up to the caller to deal wth flipping of the resulting locs.
  */
 static int
-ll2xy (l, L, xp, yp)
-double l, L;
-int *xp, *yp;
+ll2xy (double l, double L, int * xp, int * yp)
 {
 	double sR, cR;
 	double A, sA, cA;
@@ -2733,8 +2649,7 @@ int *xp, *yp;
  * N.B. allow for flipping and the borders.
  */
 static void
-m_reportloc (x, y)
-int x, y;
+m_reportloc (int x, int y)
 {
 	double lt, lg;
 
@@ -2757,8 +2672,7 @@ int x, y;
  * N.B. we allow for flipping.
  */
 static MFeature *
-closeFeature (x, y)
-int x, y;
+closeFeature (int x, int y)
 #define	RSLOP	5
 {
 	MFeature *mfp, *smallp;
@@ -2805,8 +2719,7 @@ int x, y;
 
 /* called when hit button 3 over image */
 static void
-m_popup (ep)
-XEvent *ep;
+m_popup (XEvent * ep)
 {
 	XButtonEvent *bep;
 	int overmars;
@@ -2920,10 +2833,7 @@ m_create_popup()
  * N.B. this uses m_pa.
  */
 static void
-m_eqproject (np, ra, dec, xp, yp)
-Now *np;
-double ra, dec;
-int *xp, *yp;
+m_eqproject (Now * np, double ra, double dec, int * xp, int * yp)
 {
 	double scale = winsz/degrad(marsop->s_size/3600.0); /* pix/rad */
 	double xr, yr;
@@ -2954,11 +2864,7 @@ int *xp, *yp;
 #define M_PER   degrad(350.891962)      /* Mars' rotation period, rads/day */
 
 static void
-mars_cml(np, cmlp, sltp, pap)
-Now *np;
-double *cmlp;
-double *sltp;
-double *pap;
+mars_cml(Now * np, double * cmlp, double * sltp, double * pap)
 {
 	Obj *sp;
 	double a;	/* angle from Sun ccw to Earth seen from Mars, rads */

--- a/GUI/xephem/marsmmenu.c
+++ b/GUI/xephem/marsmmenu.c
@@ -169,9 +169,7 @@ marsm_manage ()
  * don't bother if it doesn't exist or is unmanaged now or no one is logging.
  */
 void
-marsm_update (np, how_much)
-Now *np;
-int how_much;
+marsm_update (Now * np, int how_much)
 {
 	static char fmt[] = "%7.3f";
 	Obj *eop = db_basic (SUN);
@@ -240,8 +238,7 @@ marsm_newres()
  */
 /* ARGSUSED */
 void
-marsm_newdb (appended)
-int appended;
+marsm_newdb (int appended)
 {
 	if (skybkg)
 	    marsm_update (mm_get_now(), 1);
@@ -256,10 +253,10 @@ marsm_ison()
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 void
-marsm_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+marsm_selection_mode (int whether)
 {
 	if (whether)
 	    marsm_selecting++;
@@ -274,8 +271,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 
 /* called to put up or remove the watch cursor.  */
 void
-marsm_cursor (c)
-Cursor c;
+marsm_cursor (Cursor c)
 {
 	Window win;
 
@@ -880,10 +876,10 @@ marsm_create_tvform_w()
 
 /* go through all the buttons pickable for plotting and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 static void
-marsm_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+marsm_set_buttons (int whether)
 {
 	int i, j;
 
@@ -896,10 +892,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 /* callback when the Close button is activated on the stats menu */
 /* ARGSUSED */
 static void
-marsm_sstats_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_sstats_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (msform_w);
 }
@@ -907,10 +900,7 @@ XtPointer call;
 /* callback when the the More Info button is activated */
 /* ARGSUSED */
 static void
-marsm_sstats_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_sstats_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (msform_w);
 	marsm_set_buttons(marsm_selecting);
@@ -920,10 +910,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_cpdmapping_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_cpdmapping_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtSetSensitive (tel_w, telIsOn());
 }
@@ -934,10 +921,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_option_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_option_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (client) {
 	    int *flagp = (int *)client;
@@ -960,10 +944,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_scale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_scale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	marsm_update (mm_get_now(), 1);
 }
@@ -972,10 +953,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (marsm_selecting) {
 	    char *name;
@@ -988,10 +966,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-mt_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+mt_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1046,10 +1021,7 @@ XtPointer call;
 /* called whenever the topview scene is mapped. */
 /* ARGSUSED */
 static void
-mt_map_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+mt_map_cb (Widget w, XtPointer client, XtPointer call)
 {
 	mt_track_size();
 }
@@ -1101,10 +1073,7 @@ mt_track_size()
 /* callback when topview dialog is unmapped */
 /* ARGSUSED */
 static void
-mt_unmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+mt_unmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (topview_w, False, True);
 }
@@ -1112,10 +1081,7 @@ XtPointer call;
 /* callback when main shell is popped down */
 /* ARGSUSED */
 static void
-marsm_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (msform_w);
 	XtUnmanageChild (mtform_w);
@@ -1139,10 +1105,7 @@ XtPointer call;
 /* callback from the main Close button */
 /* ARGSUSED */
 static void
-marsm_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do all the work */
 	XtPopdown (mmshell_w);
@@ -1151,10 +1114,7 @@ XtPointer call;
 /* callback to add scene to movie loop */
 /* ARGSUSED */
 static void
-marsm_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (marsm_pm, dt_w);
 }
@@ -1163,10 +1123,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_anim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_anim_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* best effect if turn off worrying about the sky background */
 	skybkg = 0;
@@ -1179,10 +1136,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1240,10 +1194,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_da_input_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_da_input_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	ScreenObj *sop;
@@ -1351,10 +1302,7 @@ marsm_fill_popup (ScreenObj *sop, int justname)
  */
 /* ARGSUSED */
 static void
-marsm_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This is a simple schematic depiction of Mars and its moons.",
@@ -1368,10 +1316,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1380,10 +1325,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-marsm_goto_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_goto_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj *op = db_basic (MARS);
 	telGoto (op);
@@ -1392,10 +1334,7 @@ XtPointer call;
 /* add one entry to the given global screenobj array.
  */
 static void
-add_screenobj (soidx, op, x, y)
-SOIdx soidx;
-Obj *op;
-int x, y;
+add_screenobj (SOIdx soidx, Obj * op, int x, int y)
 {
 	char *mem = (char *) screenobj[soidx];
 	int nmem = nscreenobj[soidx];
@@ -1422,8 +1361,7 @@ int x, y;
 
 /* reclaim any existing screenobj entries from the given collection */
 static void
-reset_screenobj(soidx)
-SOIdx soidx;
+reset_screenobj(SOIdx soidx)
 {
 	if (screenobj[soidx]) {
 	    free ((char *)screenobj[soidx]);
@@ -1436,9 +1374,7 @@ SOIdx soidx;
  * if found return the ScreenObj *, else NULL.
  */
 static ScreenObj *
-close_screenobj (soidx, x, y)
-SOIdx soidx;
-int x, y;
+close_screenobj (SOIdx soidx, int x, int y)
 {
 	ScreenObj *scop = screenobj[soidx];
 	ScreenObj *minsop = NULL;
@@ -1464,10 +1400,7 @@ int x, y;
  */
 /* ARGSUSED */
 static void
-marsm_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+marsm_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XPSAsk ("Martian moons", marsm_print);
 }
@@ -1519,8 +1452,7 @@ marsm_print ()
 }
 
 static void
-marsm_ps_annotate (np)
-Now *np;
+marsm_ps_annotate (Now * np)
 {
 	int ctrx = (int)(8.5*72/2);
 	Obj *eop = db_basic (SUN);
@@ -1738,11 +1670,7 @@ Now *np;
  *     +md[].z: in front, mars radii
  */
 static void
-marsm_draw_map (w, mop, msize, md)
-Widget w;
-Obj *mop;
-double msize;
-MoonData md[M_NMOONS];
+marsm_draw_map (Widget w, Obj * mop, double msize, MoonData md[M_NMOONS])
 {
 	Display *dsp = XtDisplay(w);
 	Window win;
@@ -1996,8 +1924,7 @@ mtm_ano (double *mX, double *mZ, int *xp, int *yp, int w2x, int arg)
 }
 
 static void
-make_gcs (w)
-Widget w;
+make_gcs (Widget w)
 {
 	Display *dsp = XtDisplay(w);
 	Window win = XtWindow(w);
@@ -2030,14 +1957,7 @@ Widget w;
  * in a bounding box tw x th.
  */
 static void
-marsm_calibline (dsp, win, gc, xc, yc, tag, tw, th, l)
-Display *dsp;
-Drawable win;
-GC gc;
-int xc, yc;
-char *tag;
-int tw, th;
-int l;
+marsm_calibline (Display * dsp, Drawable win, GC gc, int xc, int yc, char * tag, int tw, int th, int l)
 {
 	int lx = xc - l/2;
 	int rx = lx + l;
@@ -2060,16 +1980,16 @@ int l;
  * save objects and screen locs in the global screenobj array for picking.
  * this is used to draw the backgrounds for the planet closeups.
  * Based on work by: Dan Bruton <WDB3926@acs.tamu.edu>
+@param win;		window to draw on 
+@param w, h;		window size 
+@param fmag;		faintest magnitude to display 
+@param ra0, dec0;	center of patch, rads 
+@param scale;		rads per pixel 
+@param rad;		maximum radius to draw away from ra0/dec0, rads 
+@param fliptb, fliplr;	flip direction; default is S up E right 
  */
 static void
-sky_background (win, w, h, fmag, ra0,dec0,scale,rad,fliptb,fliplr)
-Drawable win;		/* window to draw on */
-unsigned w, h;		/* window size */
-int fmag;		/* faintest magnitude to display */
-double ra0, dec0;	/* center of patch, rads */
-double scale;		/* rads per pixel */
-double rad;		/* maximum radius to draw away from ra0/dec0, rads */
-int fliptb, fliplr;	/* flip direction; default is S up E right */
+sky_background (Drawable win, unsigned w, unsigned h, int fmag, double ra0,double dec0,double scale,double rad,int fliptb,int fliplr)
 {
 	static int before;
 	double cdec0 = cos(dec0);
@@ -2134,8 +2054,7 @@ int fliptb, fliplr;	/* flip direction; default is S up E right */
  * already close enough.
  */
 static void
-marsm_loadfs (ra, dec)
-double ra, dec;
+marsm_loadfs (double ra, double dec)
 {
 	Now *np = mm_get_now();
 

--- a/GUI/xephem/moonmenu.c
+++ b/GUI/xephem/moonmenu.c
@@ -329,9 +329,7 @@ m_ison()
 
 /* commanded from main to update with a new set of circumstances */
 void
-m_update (np, how_much)
-Now *np;
-int how_much;
+m_update (Now * np, int how_much)
 {
 	if (!mshell_w)
 	    return;
@@ -359,8 +357,7 @@ m_newres()
  * if we are drawing background, we'd best redraw everything.
  */
 void
-m_newdb (appended)
-int appended;
+m_newdb (int appended)
 {
 	if (option[SKY_OPT] && isUp(mshell_w)) {
 	    if (!appended)
@@ -372,10 +369,10 @@ int appended;
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	 whether setting up for plotting or for not plotting 
  */
 void
-m_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+m_selection_mode (int whether)
 {
 	if (whether)
 	    m_selecting++;
@@ -391,8 +388,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 
 /* called to put up or remove the watch cursor.  */
 void
-m_cursor (c)
-Cursor c;
+m_cursor (Cursor c)
 {
 	Window win;
 
@@ -1178,10 +1174,10 @@ m_create_esform()
 
 /* go through all the buttons pickable for plotting and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	 whether setting up for plotting or for not plotting 
  */
 static void
-m_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+m_set_buttons (int whether)
 {
 	buttonAsButton (sunalt_w, whether);
 	buttonAsButton (srlng_w, whether);
@@ -1196,10 +1192,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 /* callback from the Apply button in the earthshine dialog */
 /* ARGSUSED */
 static void
-m_eshine_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_eshine_cb (Widget w, XtPointer client, XtPointer call)
 {
 	m_redraw();
 }
@@ -1207,10 +1200,7 @@ XtPointer call;
 /* callback to add the current scene to the movie loop */
 /* ARGSUSED */
 static void
-m_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (m_pm, dt_w);
 }
@@ -1218,10 +1208,7 @@ XtPointer call;
 /* callback from the Close button in the earthshine dialog */
 /* ARGSUSED */
 static void
-m_eshineclose_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_eshineclose_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (esform_w);
 }
@@ -1229,10 +1216,7 @@ XtPointer call;
 /* called to toggle whether the earthshine eshineactor is dialog */
 /* ARGSUSED */
 static void
-m_eshineup_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_eshineup_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XtIsManaged(esform_w))
 	    XtUnmanageChild (esform_w);
@@ -1245,10 +1229,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_mstats_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_mstats_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (msform_w);
 }
@@ -1257,10 +1238,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_mstats_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_mstats_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (msform_w);
 	m_set_buttons(m_selecting);
@@ -1269,10 +1247,7 @@ XtPointer call;
 /* callback from the Print PB */
 /* ARGSUSED */
 static void
-m_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_print_cb (Widget w, XtPointer client, XtPointer call)
 {
         XPSAsk ("Moon View", m_print);
 }
@@ -1415,10 +1390,7 @@ m_ps_annotate ()
  */
 /* ARGSUSED */
 static void
-m_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (m_selecting) {
 	    char *name;
@@ -1431,10 +1403,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (esform_w);
 	XtUnmanageChild (msform_w);
@@ -1463,10 +1432,7 @@ XtPointer call;
 
 /* called from Close button */
 static void
-m_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (mshell_w);
 	/* let popdown do all the work */
@@ -1477,10 +1443,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_option_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_option_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Option opt = (Option)client;
 	int set;
@@ -1545,10 +1508,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_shrink_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_shrink_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int f = (long int)client;
 	int set = XmToggleButtonGetState (w);
@@ -1564,10 +1524,7 @@ XtPointer call;
 /* callback to erase all labels */
 /* ARGSUSED */
 static void
-m_elab_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_elab_cb (Widget w, XtPointer client, XtPointer call)
 {
 	MoonDB *mp;
 
@@ -1580,10 +1537,7 @@ XtPointer call;
 /* callback for when the Movie button is activated. */
 /* ARGSUSED */
 static void
-m_anim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_anim_cb (Widget w, XtPointer client, XtPointer call)
 {
         mm_movie (option[SKY_OPT] ? MOVIE_SSTEPSZ : MOVIE_STEPSZ);
 }
@@ -1592,10 +1546,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "This is a depiction of the Moon.",
@@ -1609,10 +1560,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1623,9 +1571,7 @@ XtPointer call;
  * return 0 if ok (inside image) else -1.
  */
 static int
-xy2ll (x, y, ltp, lgp)
-int x, y;
-double *ltp, *lgp;
+xy2ll (int x, int y, double * ltp, double * lgp)
 {
 	double cx, cy;
 	double lt, lg;
@@ -1663,9 +1609,7 @@ double *ltp, *lgp;
  * return 0 if ok (on front side) else -1, but always return x and y.
  */
 static int
-ll2xy (lt, lg, xp, yp)
-double lt, lg;
-int *xp, *yp;
+ll2xy (double lt, double lg, int *xp, int *yp)
 {
 	double cx, cy, cz;
 	double coslt, sinlt;
@@ -1697,8 +1641,7 @@ int *xp, *yp;
  * lunar image, else return 0.
  */
 static int
-overMoon (x, y)
-int x, y;
+overMoon (int x, int y)
 {
 	/* convert to image center */
 	x -= BORD + leftmarg + moonrad;
@@ -1709,11 +1652,7 @@ int x, y;
 
 /* event handler from all Button events on the mda_w */
 static void
-m_pointer_eh (w, client, ev, continue_to_dispatch)
-Widget w;
-XtPointer client;
-XEvent *ev;
-Boolean *continue_to_dispatch;
+m_pointer_eh (Widget w, XtPointer client, XEvent * ev, Boolean *continue_to_dispatch)
 {
 	Display *dsp = ev->xany.display;
 	Window win = ev->xany.window;
@@ -1749,10 +1688,7 @@ Boolean *continue_to_dispatch;
  */
 /* ARGSUSED */
 static void
-m_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	XExposeEvent *e = &c->event->xexpose;
@@ -1826,8 +1762,7 @@ m_redraw()
  * if ep just copy that much, else copy all.
  */
 static void
-m_refresh(ep)
-XExposeEvent *ep;
+m_refresh(XExposeEvent *ep)
 {
 	Display *dsp = XtDisplay(mda_w);
 	Window win = XtWindow (mda_w);
@@ -1855,9 +1790,7 @@ XExposeEvent *ep;
 
 /* get the width, height and depth of the given drawable */
 static void
-m_getsize (d, wp, hp, dp)
-Drawable d;
-unsigned *wp, *hp, *dp;
+m_getsize (Drawable d, unsigned *wp, unsigned *hp, unsigned *dp)
 {
 	Window root;
 	int x, y;
@@ -1912,8 +1845,7 @@ m_init_gcs()
 
 /* given curlt/lg and Now compute supporting moon info in minfo */
 static void
-m_info(np)
-Now *np;
+m_info(Now * np)
 {
 	double tzo = pref_get(PREF_ZONE)==PREF_LOCALTZ ? -tz/24.0 : 0;
 	double srlng;
@@ -2190,9 +2122,7 @@ m_sky()
  * already close enough.
  */
 static void
-m_loadfs (np, ra, dec)
-Now *np;
-double ra, dec;
+m_loadfs (Now * np, double ra, double dec)
 {
 
 	if (fstars && fabs(dec-fsdec)<FSMOVE && cos(dec)*delra(ra-fsra)<FSMOVE)
@@ -2215,8 +2145,7 @@ double ra, dec;
 
 /* given a MoonDB entry, return 1 if we want to show its label now, else 0. */
 static int
-m_wantlabel (mp)
-MoonDB *mp;
+m_wantlabel (MoonDB *mp)
 {
 	/* always show if marked as persistent and labels are on */
 	if (option[LABELS_OPT] && mp->pl)
@@ -2423,13 +2352,13 @@ image_setup ()
 /* compute the left and right edge of earthshine for the given y.
  * all coords wrt to m_xim and current orientation.
  * sinsrl is sin of longitude of the rising sun.
+@param y;		image y 
+@param sinsrl;	 sin of longitude of the rising sun 
+@param right;	 whether shadow reaches to right limb 
+@param *lxp, *rxp;	 left and right x of edges of earthshine 
  */
 static int
-m_esedges (y, sinsrl, right, lxp, rxp)
-int y;		/* image y */
-double sinsrl;	/* sin of longitude of the rising sun */
-int right;	/* whether shadow reaches to right limb */
-int *lxp, *rxp;	/* left and right x of edges of earthshine */
+m_esedges (int y, double sinsrl, int right, int * lxp, int * rxp)
 {
 	int lx, rx;	/* left and right edge of scan line to darken */
 	int yc;		/* y with respect to moon center */
@@ -2542,8 +2471,7 @@ m_dbloc()
  * return 0 if all ok, else xe_msg() and return -1.
  */
 static int
-m_shrink (f)
-int f;
+m_shrink (int f)
 {
 	char msg[1024];
 	char fn[1024];
@@ -2688,10 +2616,7 @@ m_sizewidgets ()
  * N.B. we assume out is (nr/f) * (nr/f) bytes.
  */
 static void
-m_resize(in, nr, nc, f, out)
-unsigned char *in, *out;
-int nr, nc;
-int f;
+m_resize(unsigned char * in, int nr, int nc, int f, unsigned char * out)
 {
 	int outx, outy;
 	int noutx, nouty;
@@ -2889,10 +2814,7 @@ m_mark_libr ()
  * N.B. allow for flipping and the borders.
  */
 static void
-m_reportloc (dsp, win, x, y)
-Display *dsp;
-Window win;
-int x, y;
+m_reportloc (Display * dsp, Window win, int x, int y)
 {
 	double lt, lg;
 
@@ -2946,8 +2868,7 @@ m_pinfo()
  * leave glass_xim NULL if trouble.
  */
 static void
-makeGlassImage (dsp)
-Display *dsp;
+makeGlassImage (Display * dsp)
 {
 	int nbytes = (GLASSSZ*GLASSMAG+7) * (GLASSSZ*GLASSMAG+7) * mbpp/8;
 	char *glasspix = (char *) malloc (nbytes);
@@ -2979,9 +2900,7 @@ Display *dsp;
 
 /* make glassGC */
 static void
-makeGlassGC (dsp, win)
-Display *dsp;
-Window win;
+makeGlassGC (Display * dsp, Window win)
 {
 	XGCValues gcv;
 	unsigned int gcm;
@@ -2995,13 +2914,11 @@ Window win;
 
 /* handle the operation of the magnifying glass.
  * this is called whenever there is left button activity over the image.
+@param b1p, m1, b1r;	 button/motion state 
+@param wx, wy;		window coords of cursor 
  */
 static void
-doGlass (dsp, win, b1p, m1, b1r, wx, wy)
-Display *dsp;
-Window win;
-int b1p, m1, b1r;	/* button/motion state */
-int wx, wy;		/* window coords of cursor */
+doGlass (Display * dsp, Window win, int b1p, int m1, int b1r, int wx, int wy)
 {
 	static int lastwx, lastwy;
 	int rx, ry, rw, rh;		/* region */
@@ -3109,8 +3026,7 @@ int wx, wy;		/* window coords of cursor */
  * xc,yc. take care at the edges (m_xim is mnrows x mncols)
  */
 static void
-fillGlass (xc, yc)
-int xc, yc;
+fillGlass (int xc, int yc)
 {
 	int sx, sy;	/* coords in m_xim */
 	int gx, gy;	/* coords in glass_xim */
@@ -3338,9 +3254,7 @@ resetSkyObj ()
 
 /* add op at [x,y] to the list of background sky objects */
 static void
-addSkyObj (op, x, y)
-Obj *op;
-int x, y;
+addSkyObj (Obj * op, int x, int y)
 {
 	char *newmem;
 
@@ -3364,8 +3278,7 @@ int x, y;
  * return NULL if none within MAXR.
  */
 static Obj *
-closeSkyObj (x, y)
-int x, y;
+closeSkyObj (int x, int y)
 {
 	SkyObj *closesp = NULL;
 	int mind = 0;
@@ -3388,8 +3301,7 @@ int x, y;
 
 /* called when hit button 3 over image */
 static void
-m_popup (ep)
-XEvent *ep;
+m_popup (XEvent * ep)
 {
 	XButtonEvent *bep;
 	int x, y;
@@ -3485,9 +3397,7 @@ m_create_popup()
  *   there is no need to correct mp->{x,y} for flipping.
  */
 static void
-fill_popup (mp, x, y)
-MoonDB *mp;
-int x, y;
+fill_popup (MoonDB * mp, int x, int y)
 {
 	Now *np = mm_get_now();
 	double lt, lg;
@@ -3556,8 +3466,7 @@ int x, y;
  * N.B. we allow for flipping.
  */
 static MoonDB *
-closeMoonDB (x, y)
-int x, y;
+closeMoonDB (int x, int y)
 {
 	MoonDB *mp, *smallp;
 	double lt, lg;		/* location of [x,y] */
@@ -3645,10 +3554,7 @@ m_select_cb (Widget w, XtPointer client, XtPointer call)
  */
 /* ARGSUSED */
 static void
-m_pl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_pl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	MoonDB *mp;
 
@@ -3668,10 +3574,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_copy_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_copy_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Now *np = mm_get_now();
 	MoonDB *mp;
@@ -3692,10 +3595,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-m_showlo_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_showlo_cb (Widget w, XtPointer client, XtPointer call)
 {
 	MoonDB *mp;
 
@@ -3717,10 +3617,7 @@ XtPointer call;
 /* assign the object pointed to by skypu_op to Favorites
  */
 static void
-m_assign_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_assign_cb (Widget w, XtPointer client, XtPointer call)
 {
 	fav_add (skypu_op);
 }
@@ -3763,8 +3660,7 @@ m_create_skypopup()
 
 /* fill skypu_w with info from op */
 static void
-fill_skypopup (op)
-Obj *op;
+fill_skypopup (Obj * op)
 {
 	char buf[32];
 
@@ -3884,19 +3780,13 @@ mlo_create_shell()
  */
 /* ARGSUSED */
 static void
-mlo_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+mlo_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 }
 
 /* called from Close button in lunar orbiter window */
 static void
-mlo_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+mlo_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (mlo_shell_w);
 	/* let popdown do all the work */

--- a/GUI/xephem/msgmenu.c
+++ b/GUI/xephem/msgmenu.c
@@ -100,8 +100,7 @@ xe_msg (int app_alert, char *fmt, ...)
 
 /* called to put up or remove the watch cursor.  */
 void
-msg_cursor (c)
-Cursor c;
+msg_cursor (Cursor c)
 {
 	Window win;
 
@@ -128,7 +127,7 @@ msg_create_w()
 {
 	static struct {
 	    char *name;
-	    void (*cb)();
+	    void (*cb)(Widget w, XtPointer client, XtPointer call) ;
 	    char *tip;
 	} cb[] = {
 	    {"Erase", msg_erase_cb, "Erase messages"},
@@ -198,10 +197,7 @@ msg_create_w()
 /* callback from the erase pushbutton */
 /* ARGSUSED */
 static void
-msg_erase_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+msg_erase_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmTextReplace (txt_w, 0, txtl, "");
 	txtl = 0;
@@ -211,10 +207,7 @@ XtPointer call;
 /* callback from the close pushbutton */
 /* ARGSUSED */
 static void
-msg_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+msg_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (msg_w);
 }
@@ -222,10 +215,7 @@ XtPointer call;
 /* callback from the help pushbutton */
 /* ARGSUSED */
 static void
-msg_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+msg_help_cb (Widget w, XtPointer client, XtPointer call)
 {
         static char *msg[] = {
 	    "System messages"
@@ -238,8 +228,7 @@ XtPointer call;
  * Always set the vertical scroll bar to the extreme bottom.
  */
 static void
-msg_add (msg)
-char *msg;
+msg_add (char * msg)
 {
 	int l;
 
@@ -265,8 +254,7 @@ msg_scroll_down()
 
 /* print a message, p, in shell message box */
 static void
-xe_msg_alert (p)
-char *p;
+xe_msg_alert (char *p)
 {
 	static Widget apmsg_w;
 	Arg args[20];
@@ -318,10 +306,7 @@ char *p;
 /* callback from the alert message box ok pushbutton */
 /* ARGSUSED */
 static void
-alert_ok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+alert_ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (alert_w);
 }

--- a/GUI/xephem/netmenu.c
+++ b/GUI/xephem/netmenu.c
@@ -128,8 +128,7 @@ net_manage()
 /* Base64 stuff lifted from downloader */
 
 static void
-three_to_four(what, where)
-unsigned char *what, *where;
+three_to_four(unsigned char * what, unsigned char * where)
 {
 	static char Table64[64] = {
 	    'A','B','C','D','E','F','G','H',
@@ -152,8 +151,7 @@ unsigned char *what, *where;
 }
 
 static void
-string_to_base64(plain, b64)
-char *plain, *b64;
+string_to_base64(char * plain, char * b64)
 {
 	unsigned char four[4];
 	int len=strlen(plain),len2=0;
@@ -187,8 +185,7 @@ char *plain, *b64;
  * N.B. we assume buf[] ends with \r\n
  */
 static void
-addAuth (buf)
-char *buf;
+addAuth (char * buf)
 {
 	char *nm = XmTextFieldGetString (authn_w);
 	char plainbuf[1024], b64buf[1024];
@@ -1059,10 +1056,7 @@ net_save ()
 /* called from Ok */
 /* ARGSUSED */
 static void
-ok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (net_save() == 0)
 	    XtPopdown (netshell_w);
@@ -1071,10 +1065,7 @@ XtPointer call;
 /* called from Ok */
 /* ARGSUSED */
 static void
-cancel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cancel_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* outta here */
 	XtPopdown (netshell_w);
@@ -1085,10 +1076,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pw_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pw_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmTextVerifyCallbackStruct *vp = (XmTextVerifyCallbackStruct *)call;
 	int l = XmTextFieldGetLastPosition(w);
@@ -1117,10 +1105,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-tb_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+tb_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState(w)) {
 	    switch ((long int)client) {
@@ -1150,10 +1135,7 @@ XtPointer call;
 /* called from Ok */
 /* ARGSUSED */
 static void
-help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+help_cb (Widget w, XtPointer client, XtPointer call)
 {
         static char *msg[] = {"Set up network connectivity options."};
 
@@ -1167,10 +1149,7 @@ XtPointer call;
  * return 0 if ok to proceed, else -1 if trouble or timeout.
  */
 static int
-tout (maxt, fd, w)
-int maxt;
-int fd;
-int w;
+tout (int maxt, int fd, int w)
 {
 	int i;
 	    
@@ -1216,8 +1195,7 @@ int w;
  * we do this because we don't know how portable is h_errno?
  */
 static char *
-herr (errmsg)
-char *errmsg;
+herr (char * errmsg)
 {
 #if defined(HOST_NOT_FOUND) && defined(TRY_AGAIN)
 	switch (h_errno) {
@@ -1236,10 +1214,7 @@ char *errmsg;
  * return 0 if ok, else -1.
  */
 static int
-connect_to (sockfd, serv_addr, addrlen)
-int sockfd;
-struct sockaddr *serv_addr;
-int addrlen;
+connect_to (int sockfd, struct sockaddr *serv_addr, int addrlen)
 {
 #ifdef O_NONBLOCK               /* _POSIX_SOURCE */
 #define NOBLOCK O_NONBLOCK

--- a/GUI/xephem/objmenu.c
+++ b/GUI/xephem/objmenu.c
@@ -128,8 +128,7 @@ obj_newres()
  */
 /* ARGSUSED */
 void
-obj_newdb(appended)
-int appended;
+obj_newdb(int appended)
 {
 	if (!isUp(objshell_w)) {
 	    newdb = 1;
@@ -142,8 +141,7 @@ int appended;
 
 /* called to put up or remove the watch cursor.  */
 void
-obj_cursor (c)
-Cursor c;
+obj_cursor (Cursor c)
 {
 	Window win;
 
@@ -796,10 +794,7 @@ obj_unsetinfo()
  */
 /* ARGSUSED */
 static void
-obj_ctl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+obj_ctl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int id = (long int) client;
 
@@ -861,10 +856,7 @@ obj_help()
  */
 /* ARGSUSED */
 static void
-obj_type_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+obj_type_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState(w))
 	    obj_newlist();
@@ -875,10 +867,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-obj_select_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+obj_select_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int bi = (long int)client;
 	int idx = topi + bi;
@@ -896,10 +885,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-obj_scroll_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+obj_scroll_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScrollBarCallbackStruct *sp = (XmScrollBarCallbackStruct *)call;
 	int idx = sp->value;
@@ -918,10 +904,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-obj_srch_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+obj_srch_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char last_str[MAXNM];	/* last string we searched for */
 	static int last_idx;		/* index of last match for last_str */

--- a/GUI/xephem/plot_aux.c
+++ b/GUI/xephem/plot_aux.c
@@ -266,8 +266,7 @@ plot_coords (Widget da_w, DrawInfo *di, int window_x, int window_y)
 }
 
 static void
-mk_gcs (w)
-Widget w;
+mk_gcs (Widget w)
 {
 	Display *dsp = XtDisplay(w);
 	Window win = XtWindow(w);
@@ -321,11 +320,7 @@ binsplit (int i)
 }
 
 static int
-x_ticks (asdate, minx, maxx, maxticks, ticks)
-int asdate;
-double minx, maxx;
-int maxticks;
-double ticks[];
+x_ticks (int asdate, double minx, double maxx, int maxticks, double ticks[])
 {
 	double jd, minjd, maxjd;
 	double d0, d1;
@@ -385,13 +380,7 @@ double ticks[];
  * return width of string in pixels.
  */
 static int
-draw_x_label (dsp, win, asdate, v, x, y, w)
-Display *dsp;
-Window win;
-int asdate;
-double v;
-int x, y;
-int w;
+draw_x_label (Display * dsp, Window win, int asdate, double v, int x, int y, int w)
 {
 	int dir, asc, des;
 	XCharStruct ovl;

--- a/GUI/xephem/plotmenu.c
+++ b/GUI/xephem/plotmenu.c
@@ -125,8 +125,7 @@ plot_manage ()
  * selected to inform us that that button is to be included in a plot.
  */
 void
-plt_selection (name)
-char *name;
+plt_selection (char * name)
 {
 	if (!isUp(plotshell_w) || !XmToggleButtonGetState(select_w))
 	    return;
@@ -139,9 +138,7 @@ char *name;
  * might have the same field listed more than once so can't stop if find one.
  */
 void
-plt_log (name, value)
-char *name;
-double value;
+plt_log (char * name, double value)
 {
 	if (plt_fp) {
 	    PltLine *plp;
@@ -180,8 +177,7 @@ plot_ison()
 
 /* called to put up or remove the watch cursor.  */
 void
-plt_cursor (c)
-Cursor c;
+plt_cursor (Cursor c)
 {
 	Window win;
 
@@ -198,8 +194,7 @@ Cursor c;
  * what fields to plot.
  */
 static void
-plt_select(whether)
-int whether;
+plt_select(int whether)
 {
 	all_selection_mode(whether);
 }
@@ -488,10 +483,7 @@ plot_create_shell()
  */
 /* ARGSUSED */
 static void
-plt_show_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_show_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 
@@ -509,10 +501,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_loadcfg_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_loadcfg_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024];
 	FILE *fp;
@@ -564,10 +553,7 @@ XtPointer call;
 /* callback to save current configuration to file named by cfn_w. */
 /* ARGSUSED */
 static void
-plt_savecfg_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_savecfg_cb (Widget w, XtPointer client, XtPointer call)
 {
 	FILE *fp;
 	char *txt, *fn;
@@ -619,10 +605,7 @@ XtPointer call;
 /* callback to allow selecting plot fields */
 /* ARGSUSED */
 static void
-plt_select_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_select_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState(w)) {
 	    /* first turn off plotting, if on, while we change things */
@@ -639,10 +622,7 @@ XtPointer call;
 /* callback when user wants to start building a plot file */
 /* ARGSUSED */
 static void
-plt_active_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_active_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState(w)) {
 	    /* first turn off selecting, if on */
@@ -661,10 +641,7 @@ XtPointer call;
 /* callback when the main plot window is closed */
 /* ARGSUSED */
 static void
-plt_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 }
 
@@ -672,10 +649,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (plotshell_w);
 }
@@ -684,10 +658,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 static char *help_msg[] = {
 "This menu controls the plot generation and display functionality of xephem.",
@@ -701,10 +672,7 @@ static char *help_msg[] = {
  */
 /* ARGSUSED */
 static void
-plt_undo_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_undo_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (selecting_xy == X) {
 	    if (npltlines > 0) {
@@ -759,8 +727,7 @@ plt_turn_off ()
 
 /* set name as X coord on current row and change prompt to ask for Y */
 static void
-set_x (name)
-char *name;
+set_x (char * name)
 {
 	(void) strncpy (pltlines[npltlines].pl_xn, name, MAXFLDNAM-1);
 	set_xmstring (pltlines[npltlines].c_w[X], XmNlabelString, name);
@@ -770,8 +737,7 @@ char *name;
 
 /* set name as Y coord on current row */
 static void
-set_y (name)
-char *name;
+set_y (char * name)
 {
 	(void) strncpy (pltlines[npltlines].pl_yn, name, MAXFLDNAM-1);
 	set_xmstring (pltlines[npltlines].c_w[Y], XmNlabelString, name);
@@ -868,10 +834,10 @@ plt_try_turn_on()
 
 /* turn on plotting.
  * establish a file to use (and thereby set plt_fp, the plotting_is_on flag).
+@param *how;	fopen how argument
  */
 static void
-plt_turn_on (how)
-char *how;	/* fopen how argument */
+plt_turn_on (char * how)
 {
 	char buf[1024], *fn;
 	char *txt;
@@ -1141,8 +1107,7 @@ plt_da_manage(char *fn)
  *   DrawInfo and destroy the Form and hence everything in it.
  */
 static void
-plt_da_destroy (da_w)
-Widget da_w;
+plt_da_destroy (Widget da_w)
 {
 	Widget daform_w = XtParent(da_w);
 	DrawInfo *di;
@@ -1208,10 +1173,7 @@ plt_print()
  */
 /* ARGSUSED */
 static void
-plt_da_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Widget da_w = (Widget)client;
 
@@ -1224,10 +1186,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Widget da_w = (Widget)client;
 	XmUpdateDisplay (da_w);		/* handle expose after pulldown menu */
@@ -1239,10 +1198,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild ((Widget)client);
 }
@@ -1252,10 +1208,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_unmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_unmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	plt_da_destroy ((Widget)client);
 }
@@ -1266,10 +1219,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_flipx_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_flipx_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *t = (XmToggleButtonCallbackStruct *) call;
 	Widget da_w = (Widget) client;
@@ -1305,10 +1255,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_flipy_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_flipy_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *t = (XmToggleButtonCallbackStruct *) call;
 	Widget da_w = (Widget) client;
@@ -1344,10 +1291,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_grid_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_grid_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *t = (XmToggleButtonCallbackStruct *) call;
 	Widget da_w = (Widget) client;
@@ -1383,10 +1327,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_xyr_asdate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_xyr_asdate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *t = (XmToggleButtonCallbackStruct *) call;
 	Widget da_w = (Widget) client;
@@ -1429,10 +1370,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_xjd_asdate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+plt_da_xjd_asdate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *t = (XmToggleButtonCallbackStruct *) call;
 	Widget da_w = (Widget) client;
@@ -1475,10 +1413,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-plt_da_exp_cb (da_w, client, call)
-Widget da_w;
-XtPointer client;
-XtPointer call;
+plt_da_exp_cb (Widget da_w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 
@@ -1516,11 +1451,7 @@ XtPointer call;
  * report data at that location
  */
 static void
-plt_da_motion_eh (da_w, client, ev, continue_to_dispatch)
-Widget da_w;
-XtPointer client;
-XEvent *ev;
-Boolean *continue_to_dispatch;
+plt_da_motion_eh (Widget da_w, XtPointer client, XEvent * ev, Boolean * continue_to_dispatch)
 {
 	Display *dsp = XtDisplay(da_w);
 	Window win = XtWindow(da_w);
@@ -1543,8 +1474,7 @@ Boolean *continue_to_dispatch;
  * remember: the parent of the da is the form and it's userData is the di info.
  */
 static void
-plt_drawall (da_w)
-Widget da_w;
+plt_drawall (Widget da_w)
 {
 	Dimension w, h;
 	Widget daform_w;

--- a/GUI/xephem/preferences.c
+++ b/GUI/xephem/preferences.c
@@ -135,8 +135,7 @@ static int prefs[NPREFS];
  * also, tack on some Save and resource controls.
  */
 void
-pref_create_pulldown (menu_bar)
-Widget menu_bar;
+pref_create_pulldown (Widget menu_bar)
 {
 	Widget w, cb_w, pd;
 	Arg args[20];
@@ -191,8 +190,7 @@ Widget menu_bar;
 /* called anytime we want to know a preference.
  */
 int
-pref_get(pref)
-Preferences pref;
+pref_get(Preferences pref)
 {
 	return (prefs[pref]);
 }
@@ -201,9 +199,7 @@ Preferences pref;
  * Use this wisely.. it does *not* change the menu system.
  */
 int
-pref_set (pref, new)
-Preferences pref;
-int new;
+pref_set (Preferences pref, int new)
 {
 	int prior = pref_get(pref);
 	prefs[pref] = new;
@@ -219,11 +215,10 @@ confirm()
 
 /* build one option off the given pulldown menu.
  * for pairs, state of first fallback[] sets other; for triples must set all 3.
+@param pd;	parent pulldown menu 
  */
 static void
-pref_build (pd, pp)
-Widget pd;	/* parent pulldown menu */
-PrefSet *pp;
+pref_build (Widget pd, PrefSet * pp)
 {
 	Widget pr, cb_w;
 	Widget tb1_w, tb2_w, tb3_w;
@@ -312,10 +307,7 @@ PrefSet *pp;
  */
 /* ARGSUSED */
 static void
-pref_date_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_date_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -330,10 +322,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_units_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_units_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -348,10 +337,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_tz_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_tz_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -366,10 +352,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_dpy_prec_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_dpy_prec_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -384,10 +367,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_topogeo_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_topogeo_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -402,10 +382,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_msg_bell_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_msg_bell_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -419,10 +396,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_prefill_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_prefill_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -436,10 +410,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_tips_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_tips_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -453,10 +424,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_confirm_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_confirm_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 
@@ -470,10 +438,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pref_weekstart_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pref_weekstart_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *s = (XmToggleButtonCallbackStruct *)call;
 

--- a/GUI/xephem/progress.c
+++ b/GUI/xephem/progress.c
@@ -81,8 +81,7 @@ pm_down()
 /* set the given percentage on the progress meter.
  */
 void
-pm_set (p)
-int p;
+pm_set (int p)
 {
 	if (!isUp(pmshell_w))
 	    return;
@@ -90,8 +89,7 @@ int p;
 }
 
 void
-pm_cursor(c)
-Cursor c;
+pm_cursor(Cursor c)
 {
 	Window win;
 
@@ -182,10 +180,7 @@ pm_createshell()
 /* called from the Close PB */
 /* ARGSUSED */
 static void
-pm_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pm_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (pmshell_w);
 }
@@ -194,10 +189,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-pm_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+pm_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 
@@ -236,9 +228,7 @@ XtPointer call;
  * update cur_per and last_per when finished.
  */
 static void
-show_progress (p, force)
-int p;
-int force;
+show_progress (int p, int force)
 {
 	int new = 0;
 

--- a/GUI/xephem/ps.c
+++ b/GUI/xephem/ps.c
@@ -118,9 +118,7 @@ static Pixel haloCache (Display *dsp, Pixel p);
 /* ask user to save or print. if ok, call his go() after we've called XPSOpen()
  */
 void
-XPSAsk (apname, go)
-char *apname;
-void (*go)();
+XPSAsk (char * apname, void (*go)())
 {
 	char buf[1024];
 
@@ -167,8 +165,7 @@ XPSDrawing()
  * not the same as not drawing, since this will white-out stuff.
  */
 void
-XPSPaperColor (p)
-unsigned long p;
+XPSPaperColor (unsigned long p)
 {
     	xpsc.papercolorset = 1;
     	xpsc.papercolor = p;
@@ -179,9 +176,7 @@ unsigned long p;
  * N.B. caller should make a copy of the returned sttring before calling again.
  */
 char *
-XPSCleanStr (s, l)
-char *s;
-int l;
+XPSCleanStr (char * s, int l)
 {
 	static char *lasts;
 	int i, o;
@@ -201,8 +196,7 @@ int l;
 
 /* called to put up or remove the watch cursor.  */
 void
-XPS_cursor (c)
-Cursor c;
+XPS_cursor (Cursor c)
 {
 	Window win;
 
@@ -222,15 +216,15 @@ Cursor c;
  * points. This allows any X rectangle to me mapped into any Postscript
  * rectangle, scaled but with the same aspect ratio.
  * we also define some handy functions.
+@param win;	 what window we are capturing 
+@param Xx0, Xy0;	ul origin of X rectangle 
+@param Xw;		width of X rectangle -- clipped if Xh > 0
+@param Xh;		height of X rectangle -- > 0 means to clip 
+@param Px0, Py0;	ul origin of Page rectangle 
+@param Pw;		width of Page rectangle 
  */
 void
-XPSXBegin (win, Xx0, Xy0, Xw, Xh, Px0, Py0, Pw)
-Window win;	/* what window we are capturing */
-int Xx0, Xy0;	/* ul origin of X rectangle */
-int Xw;		/* width of X rectangle -- clipped if Xh > 0*/
-int Xh;		/* height of X rectangle -- > 0 means to clip */
-int Px0, Py0;	/* ul origin of Page rectangle */
-int Pw;		/* width of Page rectangle */
+XPSXBegin (Window win, int Xx0, int Xy0, int Xw, int Xh, int Px0, int Py0, int Pw)
 {
 	checkState ("Begin", OPEN);
 
@@ -567,8 +561,7 @@ XPSXEnd()
 /* add a raw PS string to the file.
  */
 void
-XPSDirect (s)
-char *s;
+XPSDirect (char * s)
 {
 	checkState ("Direct", OPEN);
 
@@ -635,16 +628,13 @@ XPSClose()
 /* draw a rotated ellipse.
  * easy for postscript, not so for X.
  * all angles are 64ths degree, 0 is 3oclock, positive ccw (all like in X).
+@param x, y;	 bounding box upper left corner 
+@param a0;		 axis rotation 
+@param w, h;	 bounding box width, height 
+@param a1, a2;	 initial angle, additional extent 
  */
 void
-XPSDrawEllipse (dsp, win, gc, x, y, a0, w, h, a1, a2)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;	/* bounding box upper left corner */
-int a0;		/* axis rotation */
-unsigned w, h;	/* bounding box width, height */
-int a1, a2;	/* initial angle, additional extent */
+XPSDrawEllipse (Display * dsp, Drawable win, GC gc, int x, int y, int a0, unsigned w, unsigned h, int a1, int a2)
 {
 	doEllipse (0, dsp, win, gc, x, y, a0, w, h, a1, a2);
 }
@@ -652,16 +642,13 @@ int a1, a2;	/* initial angle, additional extent */
 /* fill a rotated ellipse.
  * easy for postscript, not so for X.
  * all angles are 64ths degree, 0 is 3oclock, positive ccw (all like in X).
+@param x, y;	 bounding box upper left corner 
+@param a0;		 axis rotation 
+@param w, h;	 bounding box width, height 
+@param a1, a2;	 initial angle, additional extent 
  */
 void
-XPSFillEllipse (dsp, win, gc, x, y, a0, w, h, a1, a2)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;	/* bounding box upper left corner */
-int a0;		/* axis rotation */
-unsigned w, h;	/* bounding box width, height */
-int a1, a2;	/* initial angle, additional extent */
+XPSFillEllipse (Display * dsp, Drawable win, GC gc, int x, int y, int a0, unsigned w, unsigned h, int a1, int a2)
 {
 	doEllipse (1, dsp, win, gc, x, y, a0, w, h, a1, a2);
 }
@@ -670,13 +657,7 @@ int a1, a2;	/* initial angle, additional extent */
  * function, then might also draw to the xpsc state if it matches the win.
  */
 void
-XPSDrawArc (dsp, win, gc, x, y, w, h, a1, a2)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-unsigned w, h;
-int a1, a2;
+XPSDrawArc (Display * dsp, Drawable win, GC gc, int x, int y, unsigned w, unsigned h, int a1, int a2)
 {
 	XArc xa;
 
@@ -696,12 +677,7 @@ int a1, a2;
 }
 
 void
-XPSDrawArcs (dsp, win, gc, xa, nxa)
-Display *dsp;
-Drawable win;
-GC gc;
-XArc xa[];
-int nxa;
+XPSDrawArcs (Display * dsp, Drawable win, GC gc, XArc xa[], int nxa)
 {
 	int i;
 
@@ -716,12 +692,7 @@ int nxa;
 }
 
 void
-XPSDrawLine (dsp, win, gc, x1, y1, x2, y2)
-Display *dsp;
-Drawable win;
-GC gc;
-int x1, y1;
-int x2, y2;
+XPSDrawLine (Display * dsp, Drawable win, GC gc, int x1, int y1, int x2, int y2)
 {
 	XDrawLine (dsp, win, gc, x1, y1, x2, y2);
 	if (xpsc.state != XDRAWING || xpsc.win != win)
@@ -735,13 +706,7 @@ int x2, y2;
 }
 
 void
-XPSDrawLines (dsp, win, gc, xp, nxp, mode)
-Display *dsp;
-Drawable win;
-GC gc;
-XPoint xp[];
-int nxp;
-int mode;
+XPSDrawLines (Display * dsp, Drawable win, GC gc, XPoint xp[], int nxp, int mode)
 {
 	XDrawLines (dsp, win, gc, xp, nxp, mode);
 	if (xpsc.state != XDRAWING || xpsc.win != win || nxp < 2)
@@ -753,11 +718,7 @@ int mode;
 }
 
 void
-XPSDrawPoint (dsp, win, gc, x, y)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
+XPSDrawPoint (Display * dsp, Drawable win, GC gc, int x, int y)
 {
 	XArc xa;
 	XDrawPoint (dsp, win, gc, x, y);
@@ -777,13 +738,7 @@ int x, y;
 }
 
 void
-XPSDrawPoints (dsp, win, gc, xp, nxp, mode)
-Display *dsp;
-Drawable win;
-GC gc;
-XPoint xp[];
-int nxp;
-int mode;
+XPSDrawPoints (Display * dsp, Drawable win, GC gc, XPoint xp[], int nxp, int mode)
 {
 	int i;
 
@@ -807,12 +762,7 @@ int mode;
 }
 
 void
-XPSDrawRectangle (dsp, win, gc, x, y, w, h)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-unsigned w, h;
+XPSDrawRectangle (Display * dsp, Drawable win, GC gc, int x, int y, unsigned w, unsigned h)
 {
 	XDrawRectangle (dsp, win, gc, x, y, w, h);
 	if (xpsc.state != XDRAWING || xpsc.win != win)
@@ -824,12 +774,7 @@ unsigned w, h;
 }
 
 void
-XPSDrawRectangles (dsp, win, gc, xra, nxr)
-Display *dsp;
-Drawable win;
-GC gc;
-XRectangle xra[];
-int nxr;
+XPSDrawRectangles (Display * dsp, Drawable win, GC gc, XRectangle xra[], int nxr)
 {
 	XRectangle *lastxra;
 
@@ -844,12 +789,7 @@ int nxr;
 }
 
 void
-XPSDrawSegments (dsp, win, gc, xs, nxs)
-Display *dsp;
-Drawable win;
-GC gc;
-XSegment xs[];
-int nxs;
+XPSDrawSegments (Display * dsp, Drawable win, GC gc, XSegment xs[], int nxs)
 {
 	int i;
 
@@ -872,13 +812,7 @@ int nxs;
 /* draw using the font from gc which matches a previously Registered PS font.
  */
 void
-XPSDrawString (dsp, win, gc, x, y, s, l)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-char *s;
-int l;
+XPSDrawString (Display * dsp, Drawable win, GC gc, int x, int y, char * s, int l)
 {
 	unsigned long gcm;
 	XGCValues gcv;
@@ -913,16 +847,7 @@ int l;
  * mag is factor of how much larger than basic fs to draw.
  */
 void
-XPSRotDrawAlignedString (dsp, fs, angle, mag, win, gc, x, y, str, align)
-Display *dsp;
-XFontStruct *fs;
-double angle;
-double mag;
-Drawable win;
-GC gc;
-int x, y;
-char *str;
-int align;
+XPSRotDrawAlignedString (Display * dsp, XFontStruct *fs, double angle, double mag, Drawable win, GC gc, int x, int y, char * str, int align)
 {
 	PSFontInfo *fi;
 	char *clean;
@@ -1004,12 +929,7 @@ int align;
 /* like XPSFillArc if filling a complete circle but tries to antialias.
  */
 void
-XPSDrawStar (dsp, win, gc, x, y, d)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-int d;
+XPSDrawStar (Display * dsp, Drawable win, GC gc, int x, int y, int d)
 {
 	XArc xa;
 
@@ -1029,13 +949,7 @@ int d;
 }
 
 void
-XPSFillArc (dsp, win, gc, x, y, w, h, a1, a2)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-unsigned w, h;
-int a1, a2;
+XPSFillArc (Display * dsp, Drawable win, GC gc, int x, int y, unsigned w, unsigned h, int a1, int a2)
 {
 	XArc xa;
 
@@ -1058,12 +972,7 @@ int a1, a2;
 }
 
 void
-XPSFillArcs (dsp, win, gc, xap, na)
-Display *dsp;
-Drawable win;
-GC gc;
-XArc *xap;
-int na;
+XPSFillArcs (Display * dsp, Drawable win, GC gc, XArc *xap, int na)
 {
 	XArc *ap, *lastap;
 
@@ -1086,14 +995,7 @@ int na;
 }
 
 void
-XPSFillPolygon (dsp, win, gc, xp, nxp, shape, mode)
-Display *dsp;
-Drawable win;
-GC gc;
-XPoint xp[];
-int nxp;
-int shape;
-int mode;
+XPSFillPolygon (Display * dsp, Drawable win, GC gc, XPoint xp[], int nxp, int shape, int mode)
 {
 	XFillPolygon (dsp, win, gc, xp, nxp, shape, mode);
 	if (xpsc.state != XDRAWING || xpsc.win != win)
@@ -1112,12 +1014,7 @@ int mode;
 
 
 void
-XPSFillRectangle (dsp, win, gc, x, y, w, h)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-unsigned w, h;
+XPSFillRectangle (Display * dsp, Drawable win, GC gc, int x, int y, unsigned w, unsigned h)
 {
 	XFillRectangle (dsp, win, gc, x, y, w, h);
 	if (xpsc.state != XDRAWING || xpsc.win != win)
@@ -1129,12 +1026,7 @@ unsigned w, h;
 }
 
 void
-XPSFillRectangles (dsp, win, gc, xra, nxr)
-Display *dsp;
-Drawable win;
-GC gc;
-XRectangle xra[];
-int nxr;
+XPSFillRectangles (Display * dsp, Drawable win, GC gc, XRectangle xra[], int nxr)
 {
 	XRectangle *lastxra;
 
@@ -1150,14 +1042,14 @@ int nxr;
 /* print the given pixmap of size widxhei using colormap cm.
  * if bggc, print white for any pixel matching the bggc.
  * if black, force all overlay to be black when not in color.
+@param pm;		pixmap to print 
+@param int wid, hei;	pixmap size 
+@param cm;		pixels in pm are with respect to this colormap 
+@param bggc;		background pixel to not draw, or 0 
+@param black;		all drawing to be in black if !wantcolor 
  */
 void
-XPSPixmap (pm, wid, hei, cm, bggc, black)
-Pixmap pm;		/* pixmap to print */
-unsigned int wid, hei;	/* pixmap size */
-Colormap cm;		/* pixels in pm are with respect to this colormap */
-GC bggc;		/* background pixel to not draw, or 0 */
-int black;		/* all drawing to be in black if !wantcolor */
+XPSPixmap (Pixmap pm, unsigned int wid, unsigned int hei, Colormap cm, GC bggc, int black)
 {
 	Display *dsp = XtDisplay(toplevel_w);
 	Pixel white = WhitePixel (dsp, DefaultScreen (dsp));
@@ -1308,9 +1200,7 @@ toRGB (double h, double s, double v, double *rp, double *gp, double *bp)
  * TODO: check dash details.
  */
 static void
-setLineStyle (dsp, gc)
-Display *dsp;
-GC gc;
+setLineStyle (Display * dsp, GC gc)
 {
 	XGCValues gcv;
 	unsigned long gcm;
@@ -1325,9 +1215,7 @@ GC gc;
 
 /* set postscript value for FG color in gc. */
 static void
-setColor (dsp, gc)
-Display *dsp;
-GC gc;
+setColor (Display * dsp, GC gc)
 {
 	XGCValues gcv;
 	XColor xc;
@@ -1363,9 +1251,7 @@ GC gc;
 /* XFill and XDraw arc. same goofyness with whether it includes outter edge.
  */
 static void
-doArc (xap, fill)
-XArc *xap;
-int fill;
+doArc (XArc * xap, int fill)
 {
 	int x = xap->x;
 	int y = xap->y;
@@ -1390,17 +1276,13 @@ int fill;
 /* draw or fill a rotated ellipse.
  * easy for postscript, not so for X.
  * all angles are 64ths degree, 0 is 3oclock, positive ccw (all like in X).
+@param x, y;	 bounding box upper left corner 
+@param a0;		 axis rotation 
+@param w, h;	 bounding box width, height 
+@param a1, a2;	 initial angle, additional extent 
  */
 static void
-doEllipse (fill, dsp, win, gc, x, y, a0, w, h, a1, a2)
-int fill;
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;	/* bounding box upper left corner */
-int a0;		/* axis rotation */
-unsigned w, h;	/* bounding box width, height */
-int a1, a2;	/* initial angle, additional extent */
+doEllipse (int fill, Display * dsp, Drawable win, GC gc, int x, int y, int a0, unsigned w, unsigned h, int a1, int a2)
 {
 #define	MAXEPTS	50	/* n points to draw a full ellipse */
 #ifndef PI
@@ -1458,11 +1340,7 @@ int a1, a2;	/* initial angle, additional extent */
 }
 
 static void
-doPoly (xp, nxp, mode, fill)
-XPoint xp[];
-int nxp;
-int mode;
-int fill;
+doPoly (XPoint xp[], int nxp, int mode, int fill)
 {
 	int i;
 
@@ -1492,9 +1370,7 @@ int fill;
 }
 
 static void
-doRect (x, y, w, h, fill)
-int x, y, w, h;
-int fill;
+doRect (int x, int y, int w, int h, int fill)
 {
 	fprintf (FP, "newpath %d %d moveto %d %d lineto %d %d lineto\n",
 				    x, y,   x+w, y,   x+w, y+h);
@@ -1504,16 +1380,13 @@ int fill;
 
 /* draw a line from [x1,y1] to [x2,y2] */
 static void
-doSegment (x1, y1, x2, y2)
-int x1, y1, x2, y2;
+doSegment (int x1, int y1, int x2, int y2)
 {
 	fprintf (FP, " %4d %4d moveto %4d %4d lineto ", x1, y1, x2, y2);
 }
 
 /* ARGSUSED */
-static int IgnoreXError(disp, event)
-Display *disp;
-XErrorEvent *event;
+static int IgnoreXError(Display * disp, XErrorEvent * event)
 {
 	return (0);
 }
@@ -1522,8 +1395,7 @@ XErrorEvent *event;
  * xe_msg() why and return NULL if trouble.
  */
 static PSFontInfo *
-find_psfont (fid)
-Font fid;
+find_psfont (Font fid)
 {
 #define	PSDEFFAM	4		/* psmaps[] when no match found */
 #define	PSDEFSIZ	12		/* default pixel size */
@@ -1672,9 +1544,7 @@ Font fid;
 }
 
 static void
-checkState (funcname, s)
-char *funcname;
-XPSState s;
+checkState (char * funcname, XPSState s)
 {
 	if (xpsc.state != s) {
 	    printf ("XPS%s(): state is %d but expected %d\n",
@@ -1684,8 +1554,7 @@ XPSState s;
 }
 
 static void
-printTime (x, y)
-int x, y;
+printTime (int x, int y)
 {
 	char *ct;
 	int ctl;
@@ -1729,8 +1598,7 @@ int x, y;
  * return 0 if ok, else report why with xe_msg(), reset xpsc and return -1.
  */
 static int
-XPSOpen (fn)
-char *fn;
+XPSOpen (char * fn)
 {
 	checkState ("Open", ASKING);
 
@@ -2000,10 +1868,7 @@ create_print_w()
  */
 static void
 /* ARGSUSED */
-toggle_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+toggle_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState(w)) {
 	    Widget otherw = (Widget)client;
@@ -2023,10 +1888,7 @@ no_go()
 /* called when the Ok button is hit in the print dialog */
 /* ARGSUSED */
 static void
-ok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	xpsc.wantcolor = XmToggleButtonGetState (color_w);
 	xpsc.wantA4 = XmToggleButtonGetState (A4_w);
@@ -2068,10 +1930,7 @@ XtPointer call;
 /* called by Cancel */
 /* ARGSUSED */
 static void
-cancel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cancel_cb (Widget w, XtPointer client, XtPointer call)
 {
 	no_go();
 	XtPopdown (print_w);
@@ -2080,10 +1939,7 @@ XtPointer call;
 /* called by Help */
 /* ARGSUSED */
 static void
-help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Select Color or Grayscale;",
@@ -2158,12 +2014,7 @@ call_go ()
  * use custom bitmaps because many X servers get it poorly.
  */
 static void
-x_fill_circle (dsp, win, gc, x, y, diam)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-int diam;
+x_fill_circle (Display * dsp, Drawable win, GC gc, int x, int y, int diam)
 {
 	static unsigned char star2_bits[] = {
 	   0x03, 0x03};
@@ -2241,12 +2092,7 @@ int diam;
  * try to simulate antialiasing.
  */
 static void
-x_drawstar (dsp, win, gc, x, y, diam)
-Display *dsp;
-Drawable win;
-GC gc;
-int x, y;
-int diam;
+x_drawstar (Display * dsp, Drawable win, GC gc, int x, int y, int diam)
 {
 	static GC gc1;
 	XGCValues gcv;

--- a/GUI/xephem/query.c
+++ b/GUI/xephem/query.c
@@ -65,8 +65,7 @@ void (*func2)())	/* func to call if button 2 is pushed */
 }
 
 static Widget
-query_create(tw)
-Widget tw;
+query_create(Widget tw)
 {
 	Widget q_w;
 	Arg args[20];
@@ -90,10 +89,7 @@ Widget tw;
  */
 /* ARGSUSED */
 static void
-query_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+query_cb (Widget w, XtPointer client, XtPointer call)
 {
 	void (*f)() = funcs[(long int)client];
 

--- a/GUI/xephem/rotated.c
+++ b/GUI/xephem/rotated.c
@@ -131,26 +131,29 @@ static struct style_template {
 /* ---------------------------------------------------------------------- */
 
 
-static char            *my_strdup();
-static char            *my_strtok();
+static char            *my_strdup(char *str);
+static char            *my_strtok(char *, char *);
 
-float                   XRotVersion();
-void                    XRotSetMagnification();
-void                    XRotSetBoundingBoxPad();
-int                     XRotDrawString();
-int                     XRotDrawImageString();
-int                     XRotDrawAlignedString();
-int                     XRotDrawAlignedImageString();
-XPoint                 *XRotTextExtents();
+float XRotVersion(char * str, int n) ;
+void XRotSetMagnification(float m) ;
+void XRotSetBoundingBoxPad(int p) ;
+int XRotDrawString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * str) ;
+int XRotDrawImageString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * str) ;
+int XRotDrawAlignedString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text, int align) ;
+int XRotDrawAlignedImageString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text, int align);
+XPoint *XRotTextExtents(Display * dpy, XFontStruct * font, float angle, int x, int y, char* text, int align) ;
 
-static XImage          *MakeXImage();
-static int              XRotPaintAlignedString();
-static int              XRotDrawHorizontalString();
-static RotatedTextItem *XRotRetrieveFromCache();
-static RotatedTextItem *XRotCreateTextItem();
-static void             XRotAddToLinkedList();
-static void             XRotFreeTextItem();
-static XImage          *XRotMagnifyImage();
+static XImage *MakeXImage(Display * dpy, int w, int h) ;
+static int XRotPaintAlignedString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text,
+                                 int align, int bg) ;
+static int XRotDrawHorizontalString(Display * dpy, XFontStruct * font, Drawable drawable, GC gc, int x, int y, char * text,
+                            int align, int bg) ;
+static RotatedTextItem *XRotRetrieveFromCache(Display * dpy, XFontStruct * font, float angle, char * text, int align) ;
+static RotatedTextItem *XRotCreateTextItem(Display * dpy, XFontStruct * font, float angle, char * text, int align) ;
+static void XRotAddToLinkedList(Display * dpy, RotatedTextItem * item) ;
+static void XRotFreeTextItem(Display * dpy, RotatedTextItem * item) ;
+static XImage *XRotMagnifyImage(Display * dpy, XImage * ximage) ;
+
 
 
 /* ---------------------------------------------------------------------- */
@@ -160,8 +163,7 @@ static XImage          *XRotMagnifyImage();
 /* Routine to mimic `strdup()' (some machines don't have it)              */
 /**************************************************************************/
 
-static char *my_strdup(str)
-    char *str;
+static char *my_strdup(char * str)
 {
     char *s;
     
@@ -184,8 +186,7 @@ static char *my_strdup(str)
 /* it encounters two consecutive delimiters                               */
 /**************************************************************************/
 
-static char *my_strtok(str1, str2)
-    char *str1, *str2;
+static char *my_strtok(char * str1, char * str2)
 {
     char *ret;
     int i, j, stop;
@@ -235,9 +236,7 @@ static char *my_strtok(str1, str2)
 /* Return version/copyright information                                   */
 /**************************************************************************/
 
-float XRotVersion(str, n)
-    char *str;
-    int n;
+float XRotVersion(char * str, int n)
 {
     if(str!=NULL)
 	strncpy(str, XV_COPYRIGHT, n);
@@ -252,8 +251,7 @@ float XRotVersion(str, n)
 /* Set the font magnification factor for all subsequent operations        */
 /**************************************************************************/
 
-void XRotSetMagnification(m)
-    float m;
+void XRotSetMagnification(float m)
 {
     if(m>0.)
 	style.magnify=(float)m;
@@ -267,8 +265,7 @@ void XRotSetMagnification(m)
 /* Set the padding used when calculating bounding boxes                   */
 /**************************************************************************/
 
-void XRotSetBoundingBoxPad(p)
-    int p;
+void XRotSetBoundingBoxPad(int p)
 {
     if(p>=0)
 	style.bbx_pad=p;
@@ -282,9 +279,7 @@ void XRotSetBoundingBoxPad(p)
 /*  Create an XImage structure and allocate memory for it                 */
 /**************************************************************************/
 
-static XImage *MakeXImage(dpy, w, h)
-    Display *dpy;
-    int w, h;
+static XImage *MakeXImage(Display * dpy, int w, int h)
 {
     XImage *I;
     char *data;
@@ -313,14 +308,7 @@ static XImage *MakeXImage(dpy, w, h)
 /*      -no alignment, no background                                      */
 /**************************************************************************/
 
-int XRotDrawString(dpy, font, angle, drawable, gc, x, y, str)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    Drawable drawable;
-    GC gc;
-    int x, y;
-    char *str;
+int XRotDrawString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * str)
 {
     return (XRotPaintAlignedString(dpy, font, angle, drawable, gc,
 				   x, y, str, NONE, 0));
@@ -335,14 +323,7 @@ int XRotDrawString(dpy, font, angle, drawable, gc, x, y, str)
 /*      -no alignment, paints background                                  */
 /**************************************************************************/
 
-int XRotDrawImageString(dpy, font, angle, drawable, gc, x, y, str)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    Drawable drawable;
-    GC gc;
-    int x, y;
-    char *str;
+int XRotDrawImageString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * str)
 {
     return(XRotPaintAlignedString(dpy, font, angle, drawable, gc,
 				  x, y, str, NONE, 1));
@@ -357,15 +338,7 @@ int XRotDrawImageString(dpy, font, angle, drawable, gc, x, y, str)
 /*      -does alignment, no background                                    */
 /**************************************************************************/
 
-int XRotDrawAlignedString(dpy, font, angle, drawable, gc, x, y, text, align)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    Drawable drawable;
-    GC gc;
-    int x, y;
-    char *text;
-    int align;
+int XRotDrawAlignedString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text, int align)
 {
     return(XRotPaintAlignedString(dpy, font, angle, drawable, gc,
 				  x, y, text, align, 0));
@@ -380,16 +353,8 @@ int XRotDrawAlignedString(dpy, font, angle, drawable, gc, x, y, text, align)
 /*      -does alignment, paints background                                */
 /**************************************************************************/
 
-int XRotDrawAlignedImageString(dpy, font, angle, drawable, gc, x, y, text,
-			       align)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    Drawable drawable;
-    GC gc;
-    int x, y;
-    char *text;
-    int align;
+int XRotDrawAlignedImageString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text,
+                              int align)
 {
     return(XRotPaintAlignedString(dpy, font, angle, drawable, gc,
 				  x, y, text, align, 1));
@@ -403,17 +368,8 @@ int XRotDrawAlignedImageString(dpy, font, angle, drawable, gc, x, y, text,
 /*  Aligns and paints a rotated string                                    */
 /**************************************************************************/
 
-static int XRotPaintAlignedString(dpy, font, angle, drawable, gc, x, y, text,
-				  align, bg)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    Drawable drawable;
-    GC gc;
-    int x, y;
-    char *text;
-    int align;
-    int bg;
+static int XRotPaintAlignedString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text,
+                                 int align, int bg)
 {
     int i;
     GC my_gc;
@@ -646,16 +602,8 @@ static int XRotPaintAlignedString(dpy, font, angle, drawable, gc, x, y, text,
 /*  Draw a horizontal string in a quick fashion                           */
 /**************************************************************************/
 
-static int XRotDrawHorizontalString(dpy, font, drawable, gc, x, y, text, 
-			     align, bg)
-    Display *dpy;
-    XFontStruct *font;
-    Drawable drawable;
-    GC gc;
-    int x, y;
-    char *text;
-    int align;
-    int bg;
+static int XRotDrawHorizontalString(Display * dpy, XFontStruct * font, Drawable drawable, GC gc, int x, int y, char * text,
+                            int align, int bg)
 {
     GC my_gc;
     int nl=1, i;
@@ -747,12 +695,7 @@ static int XRotDrawHorizontalString(dpy, font, drawable, gc, x, y, text,
 /*       request, otherwise arrange for its creation                      */
 /**************************************************************************/
 
-static RotatedTextItem *XRotRetrieveFromCache(dpy, font, angle, text, align)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    char *text;
-    int align;
+static RotatedTextItem *XRotRetrieveFromCache(Display * dpy, XFontStruct * font, float angle, char * text, int align)
 {
     Font fid;
     char *font_name=NULL;
@@ -896,12 +839,7 @@ static RotatedTextItem *XRotRetrieveFromCache(dpy, font, angle, text, align)
 /*  Create a rotated text item                                            */
 /**************************************************************************/
 
-static RotatedTextItem *XRotCreateTextItem(dpy, font, angle, text, align)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    char *text;
-    int align;
+static RotatedTextItem *XRotCreateTextItem(Display * dpy, XFontStruct * font, float angle, char * text, int align)
 {
     RotatedTextItem *item=NULL;
     Pixmap canvas;
@@ -1190,9 +1128,7 @@ static RotatedTextItem *XRotCreateTextItem(dpy, font, angle, text, align)
 /*      from the front as required to keep cache size below limit         */
 /**************************************************************************/
 
-static void XRotAddToLinkedList(dpy, item)
-    Display *dpy;
-    RotatedTextItem *item;
+static void XRotAddToLinkedList(Display * dpy, RotatedTextItem * item)
 {
     
     static long int current_size=0;
@@ -1300,9 +1236,7 @@ static void XRotAddToLinkedList(dpy, item)
 /*  Free the resources used by a text item                                */
 /**************************************************************************/
 
-static void XRotFreeTextItem(dpy, item)
-    Display *dpy;
-    RotatedTextItem *item;
+static void XRotFreeTextItem(Display * dpy, RotatedTextItem * item)
 {
     free(item->text);
 
@@ -1329,9 +1263,7 @@ static void XRotFreeTextItem(dpy, item)
 /* Magnify an XImage using bilinear interpolation                         */
 /**************************************************************************/
 
-static XImage *XRotMagnifyImage(dpy, ximage)
-    Display *dpy;
-    XImage *ximage;
+static XImage *XRotMagnifyImage(Display * dpy, XImage * ximage)
 {
     int i, j;
     float x, y;
@@ -1442,13 +1374,7 @@ static XImage *XRotMagnifyImage(dpy, ximage)
 /* Calculate the bounding box some text will have when painted            */
 /**************************************************************************/
 
-XPoint *XRotTextExtents(dpy, font, angle, x, y, text, align)
-    Display *dpy;
-    XFontStruct *font;
-    float angle;
-    int x, y;
-    char *text;
-    int align;
+XPoint *XRotTextExtents(Display * dpy, XFontStruct * font, float angle, int x, int y, char* text, int align)
 {
     register int i;
     char *str1, *str2, *str3;

--- a/GUI/xephem/rotated.h
+++ b/GUI/xephem/rotated.h
@@ -58,14 +58,15 @@ XPoint *XRotTextExtents(Display*, XFontStruct*, float,
 
 #else
 
-extern float   XRotVersion();
-extern void    XRotSetMagnification();
-extern void    XRotSetBoundingBoxPad();
-extern int     XRotDrawString();
-extern int     XRotDrawImageString();
-extern int     XRotDrawAlignedString();
-extern int     XRotDrawAlignedImageString();
-extern XPoint *XRotTextExtents();
+extern float   XRotVersion(char * str, int n) ;
+extern void    XRotSetMagnification(float m) ;
+extern void    XRotSetBoundingBoxPad(int p) ;
+extern int     XRotDrawString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * str) ;
+extern int     XRotDrawImageString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * str) ;
+extern int     XRotDrawAlignedString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text, int align) ;
+extern int     XRotDrawAlignedImageString(Display * dpy, XFontStruct * font, float angle, Drawable drawable, GC gc, int x, int y, char * text, int align) ;
+extern XPoint *XRotTextExtents(Display * dpy, XFontStruct * font, float angle, int x, int y, char* text, int align) ;
+
 
 #endif /* __cplusplus */
 

--- a/GUI/xephem/satmenu.c
+++ b/GUI/xephem/satmenu.c
@@ -182,9 +182,7 @@ sm_manage ()
  * don't bother if it doesn't exist or is unmanaged now or no one is logging.
  */
 void
-sm_update (np, how_much)
-Now *np;
-int how_much;
+sm_update (Now * np, int how_much)
 {
 	static char fmt[] = "%7.3f";
 	Obj *eop = db_basic (SUN);
@@ -257,8 +255,7 @@ sm_newres()
  */
 /* ARGSUSED */
 void
-sm_newdb (appended)
-int appended;
+sm_newdb (int appended)
 {
 	if (skybkg)
 	    sm_update (mm_get_now(), 1);
@@ -273,10 +270,10 @@ sm_ison()
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	 whether setting up for plotting or for not plotting 
  */
 void
-sm_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+sm_selection_mode (int whether)
 {
 	if (whether)
 	    sm_selecting++;
@@ -291,8 +288,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 
 /* called to put up or remove the watch cursor.  */
 void
-sm_cursor (c)
-Cursor c;
+sm_cursor (Cursor c)
 {
 	Window win;
 
@@ -966,10 +962,10 @@ sm_create_tvform_w()
 
 /* go through all the buttons pickable for plotting and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 static void
-sm_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+sm_set_buttons (int whether)
 {
 	int i, j;
 
@@ -985,10 +981,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 /* callback when the Close button is activated on the stats menu */
 /* ARGSUSED */
 static void
-sm_sstats_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_sstats_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (ssform_w);
 }
@@ -996,10 +989,7 @@ XtPointer call;
 /* callback when the More Info button is activated */
 /* ARGSUSED */
 static void
-sm_sstats_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_sstats_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (ssform_w);
 	sm_set_buttons(sm_selecting);
@@ -1009,10 +999,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_cpdmapping_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_cpdmapping_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtSetSensitive (tel_w, telIsOn());
 }
@@ -1023,10 +1010,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_option_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_option_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (client) {
 	    int *flagp = (int *)client;
@@ -1049,10 +1033,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_scale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_scale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sm_update (mm_get_now(), 1);
 }
@@ -1061,10 +1042,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (sm_selecting) {
 	    char *name;
@@ -1077,10 +1055,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-st_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+st_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1135,10 +1110,7 @@ XtPointer call;
 /* called whenever the topview scene is mapped. */
 /* ARGSUSED */
 static void
-st_map_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+st_map_cb (Widget w, XtPointer client, XtPointer call)
 {
 	st_track_size();
 }
@@ -1190,10 +1162,7 @@ st_track_size()
 /* callback when topview dialog is unmapped */
 /* ARGSUSED */
 static void
-st_unmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+st_unmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (topview_w, False, True);
 }
@@ -1201,10 +1170,7 @@ XtPointer call;
 /* callback when main shell is popped down */
 /* ARGSUSED */
 static void
-sm_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (ssform_w);
 	XtUnmanageChild (stform_w);
@@ -1231,10 +1197,7 @@ XtPointer call;
 /* callback from the main Close button */
 /* ARGSUSED */
 static void
-sm_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let pop down do all the work */
 	XtPopdown (satshell_w);
@@ -1243,10 +1206,7 @@ XtPointer call;
 /* callback to add scene to movie loop */
 /* ARGSUSED */
 static void
-sm_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (sm_pm, dt_w);
 }
@@ -1255,10 +1215,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_anim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_anim_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* smoother if turn off the sky background */
 	skybkg = 0;
@@ -1271,10 +1228,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1332,10 +1286,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_da_input_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_da_input_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	ScreenObj *sop;
@@ -1404,9 +1355,8 @@ sm_create_popup()
 
 /* put up a popup at ev with info about sop */
 static void
-sm_fill_popup (sop, justname)
-ScreenObj *sop;
-int justname;
+sm_fill_popup (ScreenObj * sop, int justname)
+
 {
 	char *name;
 	double ra, dec, mag;
@@ -1444,10 +1394,7 @@ int justname;
  */
 /* ARGSUSED */
 static void
-sm_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This is a simple schematic depiction of Saturn and its moons.",
@@ -1461,10 +1408,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1473,10 +1417,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sm_goto_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_goto_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj *op = db_basic (SATURN);
 	telGoto (op);
@@ -1485,10 +1426,7 @@ XtPointer call;
 /* add one entry to the given global screenobj array.
  */
 static void
-add_screenobj (soidx, op, x, y)
-SOIdx soidx;
-Obj *op;
-int x, y;
+add_screenobj (SOIdx soidx, Obj * op, int x, int y)
 {
 	char *mem = (char *) screenobj[soidx];
 	int nmem = nscreenobj[soidx];
@@ -1515,8 +1453,7 @@ int x, y;
 
 /* reclaim any existing screenobj entries from the given collection */
 static void
-reset_screenobj(soidx)
-SOIdx soidx;
+reset_screenobj(SOIdx soidx)
 {
 	if (screenobj[soidx]) {
 	    free ((char *)screenobj[soidx]);
@@ -1529,9 +1466,7 @@ SOIdx soidx;
  * if found return the ScreenObj *, else NULL.
  */
 static ScreenObj *
-close_screenobj (soidx, x, y)
-SOIdx soidx;
-int x, y;
+close_screenobj (SOIdx soidx, int x, int y)
 {
 	ScreenObj *scop = screenobj[soidx];
 	ScreenObj *minsop = NULL;
@@ -1557,10 +1492,7 @@ int x, y;
  */
 /* ARGSUSED */
 static void
-sm_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sm_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XPSAsk ("Saturn", sm_print);
 }
@@ -1612,8 +1544,7 @@ sm_print ()
 }
 
 static void
-sm_ps_annotate (np)
-Now *np;
+sm_ps_annotate (Now * np)
 {
 	int ctrx = (int)(8.5*72/2);
 	Obj *eop = db_basic (SUN);
@@ -1832,8 +1763,7 @@ Now *np;
 
 /* given a tilt return suffix of closest image, sign same as tilt */
 static int
-sm_closesttilt (tilt)
-double tilt;
+sm_closesttilt (double tilt)
 {
 	double minerr = 1e10;
 	int mini = 0;
@@ -1861,11 +1791,10 @@ double tilt;
 /* make sure the proper gif is loaded for the given ring tilt.
  * harmless if called again.
  * return 0 if ok else -1.
+@param tilt;		ring tilt from earth, front +S rads 
  */
 static int
-sm_getgif(dsp, tilt)
-Display *dsp;
-double tilt;		/* ring tilt from earth, front +S rads */
+sm_getgif(Display * dsp, double tilt)
 {
 #define	BOGUSCT	12389
 	static int lastct = BOGUSCT;	/* last index, sign set from tilt */
@@ -1947,13 +1876,13 @@ double tilt;		/* ring tilt from earth, front +S rads */
  * lx and ly are position of upper left corner of square surrounding planet.
  * factoids: default orientation is E on right, S on top.
  * return 0 if ok, else -1
+@param *dsp;		 Display 
+@param win;		 drawable 
+@param lx, ty, sz;		 left x, top y, sz 
+@param tilt;		ring tilt from earth, front +S rads 
  */
 static int
-sm_fimage (dsp, win, lx, ty, sz, tilt)
-Display *dsp;		/* Display */
-Drawable win;		/* drawable */
-int lx, ty, sz;		/* left x, top y, sz */
-double tilt;		/* ring tilt from earth, front +S rads */
+sm_fimage (Display * dsp, Drawable win, int lx, int ty, int sz, double tilt)
 {
 	Obj *sop = db_basic (SATURN);
 	XImage *xip;
@@ -2049,11 +1978,7 @@ double tilt;		/* ring tilt from earth, front +S rads */
  *     +md[].z: in front, sat radii
  */
 static void
-sm_draw_map (sop, etilt, satsize, md)
-Obj *sop;
-double etilt;
-double satsize;
-MoonData md[S_NMOONS];
+sm_draw_map (Obj * sop, double etilt, double satsize,MoonData  md[S_NMOONS])
 {
 #define RLW     3       /* ring line width, pixels */
 #define	IRR	1.528	/* inner edge of ring system */
@@ -2392,14 +2317,7 @@ make_gcs ()
  * with is in a bounding box tw x th.
  */
 static void
-sm_calibline (dsp, win, gc, xc, yc, tag, tw, th, l)
-Display *dsp;
-Drawable win;
-GC gc;
-int xc, yc;
-char *tag;
-int tw, th;
-int l;
+sm_calibline (Display * dsp, Drawable win, GC gc, int xc, int yc, char * tag, int tw, int th, int l)
 {
 	int lx = xc - l/2;
 	int rx = lx + l;
@@ -2415,16 +2333,16 @@ int l;
  * save objects and screen locs in the global screenobj array for picking.
  * this is used to draw the backgrounds for the planet closeups.
  * Based on work by: Dan Bruton <WDB3926@acs.tamu.edu>
+@param win;		 window to draw on 
+@param w, h;		 window size 
+@param fmag;		 faintest magnitude to display 
+@param ra0, dec0;	 center of patch, rads 
+@param scale;		 rads per pixel 
+@param rad;		 maximum radius to draw away from ra0/dec0, rads 
+@param fliptb, fliplr;	 flip direction; default is S up E right 
  */
 static void
-sky_background (win, w, h, fmag, ra0,dec0,scale,rad,fliptb,fliplr)
-Drawable win;		/* window to draw on */
-unsigned w, h;		/* window size */
-int fmag;		/* faintest magnitude to display */
-double ra0, dec0;	/* center of patch, rads */
-double scale;		/* rads per pixel */
-double rad;		/* maximum radius to draw away from ra0/dec0, rads */
-int fliptb, fliplr;	/* flip direction; default is S up E right */
+sky_background (Drawable win, unsigned w, unsigned h, int fmag, double ra0,double dec0,double scale,double rad,int fliptb,int fliplr)
 {
 	static int before;
 	double cdec0 = cos(dec0);
@@ -2489,8 +2407,7 @@ int fliptb, fliplr;	/* flip direction; default is S up E right */
  * already close enough.
  */
 static void
-sm_loadfs (ra, dec)
-double ra, dec;
+sm_loadfs (double ra, double dec)
 {
 	Now *np = mm_get_now();
 

--- a/GUI/xephem/saveres.c
+++ b/GUI/xephem/saveres.c
@@ -77,7 +77,7 @@ typedef struct {
     char reg2;			/* whether to register in Save list */
     char autosav2;		/* if reg2, whether as autosav */
     XtCallbackProc cb;		/* callback */
-    int (*isf)();		/* class comparitor function */
+    int (*isf)(Widget w);		/* class comparitor function */
     char *tip;			/* help tip text */
     Widget w;			/* PB control (once created that is) */
 } Choice;
@@ -103,7 +103,7 @@ static int findCat (char *cat);
 static Resource *findRes (char *findnam);
 static int cmpRes (Resource *r1, Resource *r2);
 static char *fullWName (Widget w, char *buf);
-static void loadArgsChildren (Widget w, int (*isf)(), Arg *args, int nargs);
+static void loadArgsChildren (Widget w, int (*isf)(Widget w), Arg *args, int nargs);
 static int fgetres (char *buf, int bufl, FILE *fp);
 static void fputres (FILE *fp, char *buf);
 static void skyview_newres(void);
@@ -193,7 +193,7 @@ static int pendingexit;		/* set when saving just before exiting */
  * (can't use xm*Class in static initialization!!)
  */
 #define	CLASSCHKF(f,c1, c2)			\
-    static int f(w) Widget w; { 		\
+    static int f(Widget w) { 		\
 	WidgetClass wc = XtClass(w);		\
 	return (wc == c1 || wc == c2);		\
     }
@@ -206,7 +206,7 @@ CLASSCHKF (isList,  xmListWidgetClass, 0)
 CLASSCHKF (isText,  xmTextWidgetClass, 0)
 CLASSCHKF (isTextF, xmTextFieldWidgetClass, 0)
 CLASSCHKF (isScale, xmScaleWidgetClass, 0)
-static int isAny(w) Widget w; { return (1); }
+static int isAny(Widget w)  { return (1); }
 
 /* Font window info */
 static Widget srfshell_w;	/* main shell */
@@ -332,7 +332,7 @@ static void src_appres_cb (Widget w, XtPointer client, XtPointer call);
 static void src_obj_cb (Widget w, XtPointer client, XtPointer call);
 static void src_nightv_cb (Widget w, XtPointer client, XtPointer call);
 static void src_install (char *res, char *res2, char *cnam);
-static void src_setbg (Widget w, Pixel bg, int (*isf)());
+static void src_setbg (Widget w, Pixel bg, int (*isf)(Widget w));
 static void src_showcolor (char *name, int scalestoo);
 static void installNVBg (void);
 static void installNVFg (void);
@@ -608,11 +608,7 @@ static char prefsavecategory[] = "Main -- Preferences -- Save";
  *   value.
  */
 void
-sr_reg (w, res, cat, autosav)
-Widget w;
-char *res;
-char *cat;
-int autosav;
+sr_reg (Widget w, char * res, char * cat, int autosav)
 {
 	Resource *rp, newr, *newrp = &newr;
 	char *val;
@@ -659,8 +655,7 @@ int autosav;
 
 /* unregister all instances of the given widget */
 void
-sr_unreg (w)
-Widget w;
+sr_unreg (Widget w)
 {
 	Resource *rp, *endrp;
 
@@ -682,8 +677,7 @@ Widget w;
 
 /* called to put up or remove the watch cursor on any of the Save windows  */
 void
-sr_cursor (c)
-Cursor c;
+sr_cursor (Cursor c)
 {
 	Window win;
 
@@ -841,8 +835,7 @@ sr_isUp()
  * when finished all resources as "up to date".
  */
 int
-sr_save(talk)
-int talk;
+sr_save(int talk)
 {
 	char nam[MRNAM];	/* resource name */
 	char buf[1024];		/* handy buffer */
@@ -929,8 +922,7 @@ int talk;
  * N.B. these pixmaps should be factors out of here someday.
  */
 void
-sr_getDirPM (pmopen, pmclose)
-Pixmap *pmopen, *pmclose;
+sr_getDirPM (Pixmap * pmopen, Pixmap * pmclose)
 {
 	sr_init();
 	*pmopen = more_pm;
@@ -1199,9 +1191,7 @@ create_srshell()
 
 /* set majorn_w and minorn_w with message of counts */
 static void
-sr_setnnew (nanew, ntnew)
-int nanew;
-int ntnew;
+sr_setnnew (int nanew, int ntnew)
 {
 	char buf[128];
 
@@ -1311,10 +1301,7 @@ sr_createpms()
 
 /* ARGSUSED */
 static void
-sr_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sr_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	watch_cursor(1);
 
@@ -1335,10 +1322,7 @@ XtPointer call;
 
 /* ARGSUSED */
 static void
-sr_refresh_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sr_refresh_cb (Widget w, XtPointer client, XtPointer call)
 {
 	watch_cursor(1);
         sr_refresh();
@@ -1348,10 +1332,7 @@ XtPointer call;
 
 /* ARGSUSED */
 static void
-sr_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sr_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	pendingexit = 0;
         XtPopdown (srshell_w);
@@ -1361,10 +1342,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sr_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sr_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 static char *help_msg[] = {
 "Display preferences changed since last Save and allowing saving.",
@@ -1377,10 +1355,7 @@ static char *help_msg[] = {
  */
 /* ARGSUSED */
 static void
-sr_catexp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sr_catexp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Resource *rp = (Resource *)client;
 
@@ -1393,10 +1368,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sr_ressav_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sr_ressav_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Resource *rp = (Resource *)client;
 	rp->save = XmToggleButtonGetState(w);
@@ -1406,8 +1378,7 @@ XtPointer call;
  * first sort by category, then by fb, pushing all !autosav after all autosav.
  */
 static int
-cmpRes (r1, r2)
-Resource *r1, *r2;
+cmpRes (Resource * r1, Resource * r2)
 {
 	Category *c1 = &catlist[r1->cati];
 	Category *c2 = &catlist[r2->cati];
@@ -1424,9 +1395,7 @@ Resource *r1, *r2;
 
 /* add one entry to rc_w for the Category used by rp */
 static void
-sr_1cat (rc_w, rp)
-Widget rc_w;
-Resource *rp;
+sr_1cat (Widget rc_w, Resource * rp)
 {
 	Widget s_w, x_w, l_w, fo_w;
 	Category *cp = &catlist[rp->cati];
@@ -1493,10 +1462,7 @@ Resource *rp;
 
 /* add one entry to rc_w for the Resource rp */
 static void
-sr_1res (rc_w, rp, center)
-Widget rc_w;
-Resource *rp;
-int center;
+sr_1res (Widget rc_w, Resource * rp, int center)
 {
 	Widget s_w, l_w, v_w, fo_w;
 	Arg args[20];
@@ -1564,8 +1530,7 @@ int center;
 
 /* make a non-autosave header */
 static void
-sr_1nonas (rc_w)
-Widget rc_w;
+sr_1nonas (Widget rc_w)
 {
 	Widget w, fo_w;
 	Arg args[20];
@@ -1670,8 +1635,7 @@ sr_display()
  * return 0 if ok, or -1 if doesn't even look like a resource.
  */
 static int
-crackNam (res, nam)
-char *res, *nam;
+crackNam (char * res, char * nam)
 {
 	char *colp = strchr (res, ':');
 	char wsnam[MRNAM];
@@ -1687,8 +1651,7 @@ char *res, *nam;
  * return 0 if ok, or -1 if doesn't even look like a resource.
  */
 static int
-crackVal (res, val)
-char *res, *val;
+crackVal (char * res, char * val)
 {
 	char *colp = strchr (res, ':');
 
@@ -1702,8 +1665,7 @@ char *res, *val;
  * TODO: using XtNameToWidget precludes cases of multiple instances, eg plot.
  */
 static char *
-findWFB (findw)
-Widget findw;
+findWFB (Widget findw)
 {
 	char wnam[MRNAM];
 	Widget w;
@@ -1737,8 +1699,7 @@ Widget findw;
 /* find the fallback that corresponds to res.
  */
 static char *
-findRFB (res)
-char *res;
+findRFB (char * res)
 {
 	char fbnam[MRNAM];
 	char resnam[MRNAM];
@@ -1764,8 +1725,7 @@ char *res;
 
 /* print "nam":"val" into res; try to look nice */
 static void
-fmtRes (res, nam, val)
-char *res, *nam, *val;
+fmtRes (char * res, char * nam, char * val)
 {
 	int rl;
 
@@ -1779,9 +1739,7 @@ char *res, *nam, *val;
 /* copy from[] to to[], sans any white space on either end.
  */
 static void
-cpyNoWS (to, from)
-char *to;
-char *from;
+cpyNoWS (char * to, char * from)
 {
 	char *lastnwsp;		/* last non w/s char in to not counting '\0' */
 
@@ -1799,8 +1757,7 @@ char *from;
  * TODO: speed this up somehow making use of knowing it is in cmpRes() order?
  */
 static Resource *
-findRes (findnam)
-char *findnam;
+findRes (char * findnam)
 {
 	char nam[MRNAM];
 	int i;
@@ -1817,9 +1774,7 @@ char *findnam;
 
 /* put full name of w into buf[] */
 static char *
-fullWName (w, buf)
-Widget w;
-char *buf;
+fullWName (Widget w, char * buf)
 {
 	if (w == toplevel_w)
 	    sprintf (buf, "%s", XtName(w));
@@ -1835,8 +1790,7 @@ char *buf;
  * entry if none currently exist.
  */
 static int
-findCat (cat)
-char *cat;
+findCat (char * cat)
 {
 	Category *cp;
 
@@ -1861,13 +1815,7 @@ static char *_xrmVal;
 /* stolen from appres.c and Xlib Xrm.c */
 /*ARGSUSED*/
 static Bool
-DumpEntry(db, bindings, quarks, type, value, data)
-XrmDatabase *db;
-XrmBindingList bindings;
-XrmQuarkList quarks;
-XrmRepresentation *type;
-XrmValuePtr value;
-XPointer data;
+DumpEntry(XrmDatabase * db, XrmBindingList bindings, XrmQuarkList quarks, XrmRepresentation * type, XrmValuePtr value, XPointer data)
 {
 	static XrmQuark qstring;
 	char buf[MRNAM];
@@ -1905,8 +1853,7 @@ XPointer data;
  * if find copy malloced value to *val and return 0, else return -1.
  */
 static int
-getXrmDB (nam, val)
-char *nam, **val;
+getXrmDB (char * nam, char **val)
 {
 	XrmDatabase db = XtDatabase(XtDisplay(toplevel_w));
 	XrmName names[101];
@@ -1937,9 +1884,7 @@ char *nam, **val;
  * if we run into trouble, we just return .x and .y from w.
  */
 static void
-getGeometry (w, xp, yp)
-Widget w;
-int *xp, *yp;
+getGeometry (Widget w, int * xp, int * yp)
 {
 	Display *dsp = XtDisplay(w);
 	Window win = XtWindow (w);
@@ -1982,9 +1927,7 @@ int *xp, *yp;
  * exit if fails.
  */
 static void
-getCurVal (rp, valp)
-Resource *rp;
-char **valp;
+getCurVal (Resource * rp, char ** valp)
 {
 	/* if in night vision mode, just return the "current" value of the
 	 * resource, don't actually read its real value since we know that is
@@ -2082,11 +2025,7 @@ char **valp;
  * with args[nargs]
  */
 static void
-loadArgsChildren (w, isf, args, nargs)
-Widget w;
-int (*isf)();
-Arg *args;
-int nargs;
+loadArgsChildren (Widget w, int (*isf)(Widget w), Arg * args, int nargs)
 {
 	if (XtIsComposite (w)) {
 	    WidgetList children;
@@ -2112,13 +2051,12 @@ int nargs;
 	    XtSetValues (w, args, nargs);
 	}
 }
-
+
 /* Font control */
 
 /* display the named font in srfsample_w and store name in srfsname_w */
 static void
-srf_showsample (xlfd)
-char *xlfd;
+srf_showsample (char * xlfd)
 {
 	Display *dsp = XtDisplay (toplevel_w);
 	XFontStruct *fsp;
@@ -2145,8 +2083,7 @@ char *xlfd;
 
 /* add the given xlfd to the scrolled history list if not already present */
 static void
-srf_addhistory (xlfd)
-char *xlfd;
+srf_addhistory (char * xlfd)
 {
 	XmString xms = XmStringCreateSimple (xlfd);
 	if (!XmListItemExists (srfhl_w, xms))
@@ -2158,8 +2095,7 @@ char *xlfd;
 
 /* perform the Get-and-show current or default actions for the Choice */
 static void
-srf_getshow (fcp)
-Choice *fcp;
+srf_getshow (Choice * fcp)
 {
 	Resource *rp = findRes (fcp->res);
 	char *val = NULL;
@@ -2189,9 +2125,7 @@ Choice *fcp;
  *   evidently it must remain loaded.
  */
 static XFontStruct *
-srf_install (res, res2, xlfd)
-char *res, *res2;
-char *xlfd;
+srf_install (char * res, char * res2, char * xlfd)
 {
 	Display *dsp = XtDisplay(toplevel_w);
 	XrmDatabase db = XrmGetDatabase (dsp);
@@ -2233,10 +2167,7 @@ char *xlfd;
  */
 /* ARGSUSED */
 static void
-srf_go_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_go_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *fcp = (Choice *)client;
 	int setdef;
@@ -2284,10 +2215,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srf_appres_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_appres_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *fcp = (Choice *)client;
 	int setdef;
@@ -2318,10 +2246,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srf_views_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_views_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *fcp = (Choice *)client;
 	int setdef;
@@ -2363,10 +2288,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srf_tracking_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_tracking_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *fcp = (Choice *)client;
 	int setdef;
@@ -2406,10 +2328,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srf_moons_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_moons_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *fcp = (Choice *)client;
 	int setdef;
@@ -2448,10 +2367,7 @@ XtPointer call;
 /* called when an item in the font history list is selected */
 /* ARGSUSED */
 static void
-srf_hist_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_hist_cb (Widget w, XtPointer client, XtPointer call)
 {
         XmListCallbackStruct *lp = (XmListCallbackStruct *)call;
 	char *txt;
@@ -2465,10 +2381,7 @@ XtPointer call;
 /* called to clear font pattern field */
 /* ARGSUSED */
 static void
-srf_clear_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_clear_cb (Widget w, XtPointer client, XtPointer call)
 {
         XmTextFieldSetString (srfpat_w, "");
 }
@@ -2479,10 +2392,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srf_search_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_search_cb (Widget w, XtPointer client, XtPointer call)
 {
 	srf_search ();
 }
@@ -2490,10 +2400,7 @@ XtPointer call;
 /* called to clear font history list */
 /* ARGSUSED */
 static void
-srf_clrhistory_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_clrhistory_cb (Widget w, XtPointer client, XtPointer call)
 {
         XmListDeleteAllItems (srfhl_w);
 }
@@ -2501,10 +2408,7 @@ XtPointer call;
 /* called to close font chooser */
 /* ARGSUSED */
 static void
-srf_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_close_cb (Widget w, XtPointer client, XtPointer call)
 {
         XtPopdown (srfshell_w);
 }
@@ -2513,10 +2417,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srf_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 static char *fhelp_msg[] = {
 "Type a font, then install into the specified widgets.",
@@ -2576,10 +2477,7 @@ srf_search ()
 /* called when an item in the font list is selected */
 /* ARGSUSED */
 static void
-srf_sel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srf_sel_cb (Widget w, XtPointer client, XtPointer call)
 {
         XmListCallbackStruct *lp = (XmListCallbackStruct *)call;
 	char *txt;
@@ -2591,10 +2489,7 @@ XtPointer call;
 
 /* build menus across the given menu bar based on given array of Choices */
 static void
-create_menus (mb_w, cp, ncp)
-Widget mb_w;
-Choice *cp;
-int ncp;
+create_menus (Widget mb_w, Choice * cp, int ncp)
 {
 	Widget pd_w = (Widget)0, cb_w, w;
 	Choice *lastcp;
@@ -2915,14 +2810,12 @@ abcdefghijklmnopqrstuvwxyz\n\
 	srf_search ();
 	XtManageChild (srfaf_w);
 }
-
+
 /* Color control */
 
 /* display the named color in the sample area and maybe set scales to match */
 static void
-src_showcolor (name, scalestoo)
-char *name;
-int scalestoo;
+src_showcolor (char * name, int scalestoo)
 {
 	Display *dsp = XtDisplay(toplevel_w);
 	Window win = XtWindow (srcda_w);
@@ -2966,8 +2859,7 @@ int scalestoo;
 
 /* perform the Get-and-show current or default actions for the cchoice */
 static void
-src_getshow (ccp)
-Choice *ccp;
+src_getshow (Choice * ccp)
 {
 	Resource *rp = findRes (ccp->res);
 	char *val = NULL;
@@ -2997,10 +2889,7 @@ Choice *ccp;
 
 /* load w and its children with the background colors assoc with bg. */
 static void
-src_setbg (w, bg, isf)
-Widget w;
-Pixel bg;
-int (*isf)();
+src_setbg (Widget w, Pixel bg, int (*isf)(Widget w))
 {
 	Display *dsp = XtDisplay(w);
 	Screen *scr = DefaultScreenOfDisplay(dsp);
@@ -3025,9 +2914,7 @@ int (*isf)();
 
 /* install colorname in res{,2} in database and our history list */
 static void
-src_install (res, res2, cnam)
-char *res, *res2;
-char *cnam;
+src_install (char * res, char * res2, char * cnam)
 {
 	Display *dsp = XtDisplay(toplevel_w);
 	XrmDatabase db = XrmGetDatabase (dsp);
@@ -3073,10 +2960,7 @@ char *cnam;
  */
 /* ARGSUSED */
 static void
-src_bg_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_bg_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *ccp = (Choice *)client;
 	int setdef;
@@ -3128,10 +3012,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-src_fg_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_fg_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *ccp = (Choice *)client;
 	int setdef;
@@ -3286,10 +3167,7 @@ installNVBg()
  */
 /* ARGSUSED */
 static void
-src_nightv_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_nightv_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Display *dsp = XtDisplay(w);
 	XrmDatabase db = XrmGetDatabase (dsp);
@@ -3398,10 +3276,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-src_obj_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_obj_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *ccp = (Choice *)client;
 	int setdef;
@@ -3442,10 +3317,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-src_appres_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_appres_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Choice *ccp = (Choice *)client;
 	int setdef;
@@ -3476,10 +3348,7 @@ XtPointer call;
 /* called when an item in the color history list is selected */
 /* ARGSUSED */
 static void
-src_hist_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_hist_cb (Widget w, XtPointer client, XtPointer call)
 {
         XmListCallbackStruct *lp = (XmListCallbackStruct *)call;
 	char *txt;
@@ -3493,10 +3362,7 @@ XtPointer call;
 /* called to clear color text list */
 /* ARGSUSED */
 static void
-src_clrl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_clrl_cb (Widget w, XtPointer client, XtPointer call)
 {
         XmListDeleteAllItems (srcsl_w);
 }
@@ -3504,10 +3370,7 @@ XtPointer call;
 /* called to close color chooser */
 /* ARGSUSED */
 static void
-src_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_close_cb (Widget w, XtPointer client, XtPointer call)
 {
         XtPopdown (srcshell_w);
 }
@@ -3515,10 +3378,7 @@ XtPointer call;
 /* called when ENTER  is typed in the color text field */
 /* ARGSUSED */
 static void
-src_enter_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_enter_cb (Widget w, XtPointer client, XtPointer call)
 {
         char *txt = XmTextFieldGetString (w);
 	src_showcolor (txt, 1);
@@ -3528,10 +3388,7 @@ XtPointer call;
 /* called when RGB TB changes */
 /* ARGSUSED */
 static void
-src_rgb_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_rgb_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *rgbstr;
 
@@ -3544,10 +3401,7 @@ XtPointer call;
 /* called while any RGB/HSV scale is being dragged */
 /* ARGSUSED */
 static void
-src_scale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_scale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int r, g, b;
 	char buf[32];
@@ -3574,10 +3428,7 @@ XtPointer call;
 /* callback from the color Help button */
 /* ARGSUSED */
 static void
-src_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+src_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 static char *chelp_msg[] = {
 "Type a color name, then install into the specified widgets.",
@@ -3589,10 +3440,7 @@ static char *chelp_msg[] = {
 /* called to start color picker */
 /* ARGSUSED */
 static void
-cpk_grab_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+cpk_grab_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static Cursor wc;
 	Display *dsp = XtDisplay(w);
@@ -4030,10 +3878,7 @@ create_srcshell()
  * return 0 if ok, -1 if EOF.
  */
 static int
-fgetres (buf, bufl, fp)
-char *buf;
-int bufl;
-FILE *fp;
+fgetres (char * buf, int bufl, FILE * fp)
 {
 	int c;
 
@@ -4072,9 +3917,7 @@ FILE *fp;
  * see comment at setXRes() for more insite.
  */
 static void
-fputres (fp, buf)
-FILE *fp;
-char *buf;
+fputres (FILE * fp, char * buf)
 {
 	int c;
 

--- a/GUI/xephem/scope.c
+++ b/GUI/xephem/scope.c
@@ -135,8 +135,7 @@ sc_isGotoOn()
 /* send the given object to INDI if On and alt>0.
  */
 void
-sc_goto (op)
-Obj *op;
+sc_goto (Obj * op)
 {
 	char buf[1024];
 
@@ -212,8 +211,7 @@ Obj *op;
 
 /* called to put up or remove the watch cursor.  */
 void
-sc_cursor (c)
-Cursor c;
+sc_cursor (Cursor c)
 {
 	Window win;
 
@@ -517,10 +515,7 @@ Widget *b_wp)		/* intercept TF widget, or NULL */
 /* called when the help button is hit */
 /* ARGSUSED */
 static void
-sc_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sc_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "Configure how INDI services connect with XEphem."

--- a/GUI/xephem/sites.c
+++ b/GUI/xephem/sites.c
@@ -162,9 +162,7 @@ sites_search (char *p)
  * N.B. allow for full == NULL or full[0] == '\0'.
  */
 void
-sites_abbrev (full, ab, maxn)
-char *full, ab[];
-int maxn;
+sites_abbrev (char * full, char ab[], int maxn)
 {
 	int fl;
 	int n;
@@ -580,8 +578,7 @@ setMenuHistory (Widget w, int i)
 
 /* shift the scrolled list so sites[i] is selected and visible */
 static void
-scroll_sites (i)
-int i;
+scroll_sites (int i)
 {
 	i += 1;					/* List is 1-based */
 	XmListSetPos (sql_w, i);	 	/* scroll it to top */
@@ -720,10 +717,7 @@ sites_cmpf (const void * v1, const void * v2)
  */
 /* ARGSUSED */
 static void
-sq_set_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_set_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *str = XmTextFieldGetString (settf_w);
 	int i;
@@ -747,10 +741,7 @@ XtPointer call;
 /* called when CR is hit in the search text field /or/ from Search PB */
 /* ARGSUSED */
 static void
-sq_search_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_search_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *str;
 	int i;
@@ -770,10 +761,7 @@ XtPointer call;
 /* called when an item in the scrolled list is double-clicked */
 /* ARGSUSED */
 static void
-sq_dblclick_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_dblclick_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int *pos, npos;
 	int free;
@@ -795,10 +783,7 @@ XtPointer call;
 /* called when an item in the scrolled list is single-clicked */
 /* ARGSUSED */
 static void
-sq_click_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_click_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int *pos, npos;
 	int free;
@@ -820,10 +805,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sq_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Load and select from a list of sites."
@@ -835,10 +817,7 @@ XtPointer call;
 /* called when the Cancel button is hit */
 /* ARGSUSED */
 static void
-sq_cancel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_cancel_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (sq_w);
 }
@@ -846,10 +825,7 @@ XtPointer call;
 /* called when the Add TB is hit */
 /* ARGSUSED */
 static void
-sq_create_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_create_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState (w))
 	    XtManageChild (newf_w);
@@ -860,10 +836,7 @@ XtPointer call;
 /* called when the Set main PB is hit */
 /* ARGSUSED */
 static void
-sq_setmain_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_setmain_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Site ns;
 
@@ -875,10 +848,7 @@ XtPointer call;
 /* called when the Save PB is hit */
 /* ARGSUSED */
 static void
-sq_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sq_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char fn[1024];
 	Site ns;

--- a/GUI/xephem/skybinary.c
+++ b/GUI/xephem/skybinary.c
@@ -185,10 +185,7 @@ bs_create_shell_w()
  */
 /* ARGSUSED */
 static void
-bs_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+bs_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
         Window win = XtWindow(w);

--- a/GUI/xephem/skyeyep.c
+++ b/GUI/xephem/skyeyep.c
@@ -136,8 +136,7 @@ se_unmanage()
 
 /* called to put up or remove the watch cursor.  */
 void
-se_cursor (c)
-Cursor c;
+se_cursor (Cursor c)
 {
 	Window win;
 
@@ -1000,8 +999,7 @@ se_create_eyep_w()
 
 /* read the given w or h scale and write it's value in the given label */
 static void
-se_scale_fmt (s_w, l_w)
-Widget s_w, l_w;
+se_scale_fmt (Widget s_w, Widget l_w)
 {
 	char buf[64];
 
@@ -1012,8 +1010,7 @@ Widget s_w, l_w;
 
 /* read the given pa scale and write it's value in the given label */
 static void
-se_pascale_fmt (s_w, l_w)
-Widget s_w, l_w;
+se_pascale_fmt (Widget s_w, Widget l_w)
 {
 	char buf[64];
 
@@ -1023,10 +1020,7 @@ Widget s_w, l_w;
 
 /* called when the telrad TB is activated */
 static void
-se_telrad_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_telrad_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int set = XmToggleButtonGetState (w);
 
@@ -1053,10 +1047,7 @@ XtPointer call;
 
 /* drag callback from the height scale */
 static void
-se_hscale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_hscale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	se_scale_fmt (eyephs_w, eyephl_w);
 
@@ -1070,10 +1061,7 @@ XtPointer call;
 
 /* drag callback from the width scale */
 static void
-se_wscale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_wscale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	se_scale_fmt (eyepws_w, eyepwl_w);
 
@@ -1087,10 +1075,7 @@ XtPointer call;
 
 /* drag callback from the pa scale */
 static void
-se_pscale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_pscale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	se_pascale_fmt (eyepa_w, eyepal_w);
 }
@@ -1099,10 +1084,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_delall_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_delall_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (eyep) {
 	    if (confirm()) {
@@ -1144,10 +1126,7 @@ se_delall()
  */
 /* ARGSUSED */
 static void
-se_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (eyep_w);
 }
@@ -1155,10 +1134,7 @@ XtPointer call;
 /* called when the help button is hit in the eyepiece dialog */
 /* ARGSUSED */
 static void
-se_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "Define eyepiece shapes and sizes."
@@ -1173,10 +1149,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_skyW_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_skyW_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Widget angle_w = (Widget)client;
 	char *str;
@@ -1198,10 +1171,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_skyH_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_skyH_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Widget angle_w = (Widget)client;
 	char *str;
@@ -1221,10 +1191,7 @@ XtPointer call;
 /* called when any of the factors in formula 1 change */
 /* ARGSUSED */
 static void
-se_calc1_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_calc1_cb (Widget w, XtPointer client, XtPointer call)
 {
 	se_calc1();
 }
@@ -1268,10 +1235,7 @@ se_calc1()
 /* called when any of the factors in formula 2 change */
 /* ARGSUSED */
 static void
-se_calc2_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_calc2_cb (Widget w, XtPointer client, XtPointer call)
 {
 	se_calc2();
 }
@@ -1313,8 +1277,7 @@ se_calc2()
 
 /* read the given Scale widget and return it's current setting, in rads */
 static double
-se_getScale (w)
-Widget w;
+se_getScale (Widget w)
 {
 	int v;
 	double a;
@@ -1329,9 +1292,7 @@ Widget w;
 
 /* set the given Scale widget to the given setting, in rads */
 static void
-se_setScale (w, a)
-Widget w;
-double a;
+se_setScale (Widget w, double a)
 {
 	int v;
 
@@ -1349,8 +1310,7 @@ double a;
 
 /* read the given pos angle widget and return it's current setting, in rads */
 static double
-se_getPScale (w)
-Widget w;
+se_getPScale (Widget w)
 {
 	int v;
 
@@ -1363,10 +1323,7 @@ Widget w;
  */
 /* ARGSUSED */
 static void
-se_usefav_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_usefav_cb (Widget w, XtPointer client, XtPointer call)
 {
 	FavEyeP *fp = &favs[(long int)client];
 
@@ -1385,10 +1342,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_delfav_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_delfav_cb (Widget w, XtPointer client, XtPointer call)
 {
 	FavEyeP *fp = &favs[(long int)client];
 	XtDestroyWidget (fp->row_w);
@@ -1398,10 +1352,7 @@ XtPointer call;
 /* called to add a new FavEyeP */
 /* ARGSUSED */
 static void
-se_addfav_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_addfav_cb (Widget w, XtPointer client, XtPointer call)
 {
 	FavEyeP newfav;
 	double aunused;
@@ -1417,10 +1368,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_loadd_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_loadd_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 	get_xmstring (w, XmNlabelString, &fn);
@@ -1433,10 +1381,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_saved_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_saved_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024], *fn;
 	char *txt;
@@ -1460,10 +1405,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_loadp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_loadp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 	get_xmstring (w, XmNlabelString, &fn);
@@ -1476,10 +1418,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-se_savep_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+se_savep_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024], *fn;
 	char *txt;
@@ -1501,8 +1440,7 @@ XtPointer call;
 /* add (or reuse) a new (or unused) entry to favs[], create and show in favrc_w.
  */
 static void
-se_addFavEyeP (newfp)
-FavEyeP *newfp;
+se_addFavEyeP (FavEyeP * newfp)
 {
 	char buf[32], wstr[32], hstr[32];
 	Widget w;

--- a/GUI/xephem/skyfiltmenu.c
+++ b/GUI/xephem/skyfiltmenu.c
@@ -157,13 +157,12 @@ static char skyfcategory[] = "Sky View -- Filter";	/* Save category */
  * right away.
  */
 void
-svf_create(shell_w)
-Widget shell_w;
+svf_create(Widget shell_w)
 {
 	static struct {
 	    char *name;
 	    char *tip;
-	    void (*cb)();
+	    void (*cb)(Widget w, XtPointer client, XtPointer call);
 	} ctls[] = {
 	    /* balance in half */
 	    {"Ok", "Apply changes and close", svf_ok_cb},
@@ -391,9 +390,7 @@ svf_unmanage()
  * this is to support sky history.
  */
 void
-svf_gettables (tt, ct)
-char tt[NOBJTYPES];
-char ct[NCLASSES];
+svf_gettables (char tt[NOBJTYPES], char ct[NCLASSES])
 {
 	(void) memcpy (tt, type_table, NOBJTYPES);
 	(void) memcpy (ct, fclass_table, NCLASSES);
@@ -404,9 +401,7 @@ char ct[NCLASSES];
  * this is to support sky history.
  */
 void
-svf_settables (tt, ct)
-char tt[NOBJTYPES];
-char ct[NCLASSES];
+svf_settables (char tt[NOBJTYPES], char ct[NCLASSES])
 {
 	(void) memcpy (type_table, tt, NOBJTYPES);
 	(void) memcpy (fclass_table, ct, NCLASSES);
@@ -426,8 +421,7 @@ svf_getmaglimits (int *stmagp, int *ssmagp, int *dsmagp, int *magstpp)
 
 /* set the current deep- and near-sky limit and mag step */
 void
-svf_setmaglimits (st, ss, ds, s)
-int st, ss, ds, s;
+svf_setmaglimits (int st, int ss, int ds, int s)
 {
 	stmag = st;
 	ssmag = ss;
@@ -444,8 +438,7 @@ int st, ss, ds, s;
  *   to range check the type and class.
  */
 int
-svf_filter_ok (op)
-Obj *op;
+svf_filter_ok (Obj * op)
 {
 	int tok;
 
@@ -462,8 +455,7 @@ Obj *op;
 
 /* called to put up or remove the watch cursor.  */
 void
-svf_cursor (c)
-Cursor c;
+svf_cursor (Cursor c)
 {
 	Window win;
 
@@ -478,8 +470,7 @@ Cursor c;
 
 /* establish faintest mags according to given fov */
 void
-svf_automag(fov)
-double fov;
+svf_automag(double fov)
 {
 	static AutoMag amdef = {degrad(360.0), 6, 6, 8, 1};
 	static AutoMag *amp;
@@ -504,9 +495,7 @@ double fov;
 
 /* create one FilterCat filter category in the given RowColumn */
 static void
-svf_create_filter (mainrc, fcp)
-Widget mainrc;
-FilterCat *fcp;
+svf_create_filter (Widget mainrc, FilterCat * fcp)
 {
 	Arg args[20];
 	Widget l_w;
@@ -657,8 +646,7 @@ svf_apply()
  * is done later.
  */
 static int
-svf_bright_ok(op)
-Obj *op;
+svf_bright_ok(Obj * op)
 {
 	switch (op->o_type) {
 	case PLANET:
@@ -702,10 +690,7 @@ Obj *op;
  */
 /* ARGSUSED */
 static void
-svf_da_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_da_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	FilterTB *ftbp = (FilterTB *) client;
@@ -741,9 +726,7 @@ XtPointer call;
  * DrawingArea widget daw.
  */
 static void
-svf_draw_symbol(ftbp, daw)
-FilterTB *ftbp;
-Widget daw;
+svf_draw_symbol(FilterTB * ftbp, Widget daw)
 {
 	static GC gc;
 	static Pixel fg_p, bg_p;
@@ -789,10 +772,7 @@ Widget daw;
 /* called when either mag scale is dragged */
 /* ARGSUSED */
 static void
-svf_magdrag_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_magdrag_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sv_amagoff();
 }
@@ -800,10 +780,7 @@ XtPointer call;
 /* called when Apply is pushed on the filter dialog */
 /* ARGSUSED */
 static void
-svf_apply_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_apply_cb (Widget w, XtPointer client, XtPointer call)
 {
 	svf_apply();
 	sv_all(mm_get_now());
@@ -812,10 +789,7 @@ XtPointer call;
 /* called when Ok is pushed on the filter dialog */
 /* ARGSUSED */
 static void
-svf_ok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	svf_apply();
 	sv_all(mm_get_now());
@@ -825,10 +799,7 @@ XtPointer call;
 /* called when Close is pushed on the filter dialog */
 /* ARGSUSED */
 static void
-svf_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (filter_w);
 }
@@ -837,10 +808,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svf_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This allows settings the types of objects to display."
@@ -852,10 +820,7 @@ XtPointer call;
 /* called when Toggle is pushed on the filter dialog */
 /* ARGSUSED */
 static void
-svf_toggle_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_toggle_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i, j;
 
@@ -872,10 +837,7 @@ XtPointer call;
 /* called when All is pushed on the filter dialog */
 /* ARGSUSED */
 static void
-svf_all_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_all_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i, j;
 
@@ -891,10 +853,7 @@ XtPointer call;
 /* called when Reset is pushed on the filter dialog */
 /* ARGSUSED */
 static void
-svf_reset_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_reset_cb (Widget w, XtPointer client, XtPointer call)
 {
 	svf_reset();
 }
@@ -904,10 +863,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svf_cat_toggle_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svf_cat_toggle_cb (Widget w, XtPointer client, XtPointer call)
 {
 	FilterCat *fcp = (FilterCat *) client;
 	int i;
@@ -944,8 +900,7 @@ am_cf (const void * v1, const void * v2)
  * N.B. don't set *ampp unless we return > 0.
  */
 static int
-svf_initautomag(ampp)
-AutoMag **ampp;
+svf_initautomag(AutoMag **ampp)
 {
 	static char AMResource[] = "AutoMag";
 	double r;

--- a/GUI/xephem/skyfits.c
+++ b/GUI/xephem/skyfits.c
@@ -177,8 +177,7 @@ sf_newFITS (FImage *fip, char name[], int autocon)
  * keep hdrl up to date.
  */
 void
-sf_showHeader (fip)
-FImage *fip;
+sf_showHeader (FImage * fip)
 {
 	char *header;
 	int i;
@@ -214,11 +213,11 @@ FImage *fip;
 /* return copies of the current filename and OBJECT or TARGET keywords.
  * if either can not be determined, the returned string will be 0 length.
  * N.B. we assume the caller supplies "enough" space.
+@param *fn;	 filename 
+@param *on;	 object name 
  */
 void
-sf_getName (fn, on)
-char *fn;	/* filename */
-char *on;	/* object name */
+sf_getName (char * fn, char * on)
 {
 	FImage *fip;
 	char *savefn;
@@ -245,9 +244,7 @@ char *on;	/* object name */
 
 /* t00fri: include possibility to read .fth compressed files */
 static int
-prepOpen (fn, errmsg)
-char fn[];
-char errmsg[];
+prepOpen (char fn[], char errmsg[])
 {
 	int fd;
 	int l;
@@ -291,8 +288,7 @@ char errmsg[];
  * if all ok return 0, else return -1.
  */
 static int
-sf_readFile (name)
-char *name;
+sf_readFile (char * name)
 {
 	char buf[1024];
 	FImage fim, *fip = &fim;
@@ -664,8 +660,7 @@ sf_create()
  * we try to pull these from the basic program resources.
  */
 static void
-initFSB (fsb_w)
-Widget fsb_w;
+initFSB (Widget fsb_w)
 {
 	Widget w;
 
@@ -700,10 +695,7 @@ Widget fsb_w;
 /* callback from the Public dir PB */
 /* ARGSUSED */
 static void
-sharedDirCB (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sharedDirCB (Widget w, XtPointer client, XtPointer call)
 {
 	Widget fsb_w = (Widget)client;
 	char buf[1024];
@@ -715,10 +707,7 @@ XtPointer call;
 /* callback from the Private dir PB */
 /* ARGSUSED */
 static void
-privateDirCB (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+privateDirCB (Widget w, XtPointer client, XtPointer call)
 {
 	Widget fsb_w = (Widget)client;
 
@@ -729,8 +718,7 @@ XtPointer call;
  * set the XmNdirectory resource in the FSB fsb_w and invoke the Filter.
  */
 static void
-initPubShared (rc_w, fsb_w)
-Widget rc_w, fsb_w;
+initPubShared (Widget rc_w, Widget fsb_w)
 {
 	Arg args[20];
 	char tip[1024];
@@ -760,10 +748,7 @@ Widget rc_w, fsb_w;
 /* called when Watch TB changes */
 /* ARGSUSED */
 static void
-fw_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+fw_cb (Widget w, XtPointer client, XtPointer call)
 {
 	fw_on (XmToggleButtonGetState(w));
 }
@@ -771,10 +756,7 @@ XtPointer call;
 /* called when Get PB or toolbar PB is hit */
 /* ARGSUSED */
 void
-sf_go_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sf_go_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!sf_w) {
 	    sf_create();
@@ -795,10 +777,7 @@ XtPointer call;
 /* called when CR is hit in the Save text field or the Save PB is hit */
 /* ARGSUSED */
 static void
-sf_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sf_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 
@@ -864,10 +843,7 @@ save_file()
 /* called when a file selected by the FSB is to be opened */
 static void
 /* ARGSUSED */
-sf_open_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sf_open_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmFileSelectionBoxCallbackStruct *s =
 				    (XmFileSelectionBoxCallbackStruct *)call;
@@ -889,20 +865,14 @@ XtPointer call;
 
 /* ARGSUSED */
 static void
-sf_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sf_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (sf_w);
 }
 
 /* ARGSUSED */
 static void
-sf_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sf_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Read in local FITS files or read from Network.",
@@ -915,10 +885,7 @@ XtPointer call;
 /* callback to set main time to match FITS */
 /* ARGSUSED */
 static void
-sf_setdate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sf_setdate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	double newmjd;
 
@@ -930,8 +897,7 @@ XtPointer call;
  * preserve any existing directory.
  */
 static void
-sf_setSaveName(newfn)
-char *newfn;
+sf_setSaveName(char * newfn)
 {
 	char buf[1024];
 	char *fn;
@@ -945,8 +911,7 @@ char *newfn;
 /* return pointer to basename portion of filename fn.
  */
 static char *
-bname (fn)
-char *fn;
+bname (char * fn)
 {
 	char *base;
 
@@ -960,9 +925,7 @@ char *fn;
 
 /* return 0 if find the string str in buf, else -1 */
 static int
-chk4str (str, buf)
-char str[];
-char buf[];
+chk4str (char str[], char buf[])
 {
 	int l = strlen (str);
 
@@ -1410,10 +1373,7 @@ stsci_fits()
  * client is *FImage being accumulated.
  */
 static void
-fits_read_icb (client, fd, id)
-XtPointer client;
-int *fd;
-XtInputId *id;
+fits_read_icb (XtPointer client, int * fd, XtInputId* id)
 {
 	FImage *fip = (FImage *)client;
 	int sockfd = *fd;
@@ -1524,8 +1484,7 @@ fits_read_abort (FImage *fip)
  * return 0 if think we found something, else -1
  */
 static int
-fitsObs(mjdp)
-double *mjdp;
+fitsObs(double * mjdp)
 {
 	FImage *fip = si_getFImage();
 	char buf[128];
@@ -1608,8 +1567,7 @@ sf_setObsDate()
 /* turn on or off file watching.
  */
 static void
-fw_on (whether)
-int whether;
+fw_on (int whether)
 {
 	/* turn everything off */
 	if (fw_tid) {
@@ -1653,9 +1611,7 @@ int whether;
  * as a simple form of ACK.
  */
 static void
-fw_to (client, id)
-XtPointer client;
-XtIntervalId *id;
+fw_to (XtPointer client, XtIntervalId * id)
 {
 	char wfn[512], ffn[512];
 	char *txt, *nl;
@@ -1693,10 +1649,7 @@ XtIntervalId *id;
 /* called whenever the FITS filename fifo might have something to read.
  */
 static void
-fw_icb (client, fdp, id)
-XtPointer client;
-int *fdp;
-XtInputId *id;
+fw_icb (XtPointer client, int * fdp, XtInputId * id)
 {
 	char *nl, ffn[1024];
 	int nr;
@@ -1725,8 +1678,7 @@ XtInputId *id;
 
 /* return whether fn claims to be a fifo */
 static int
-fw_isFifo (fn)
-char *fn;
+fw_isFifo (char * fn)
 {
 	struct stat st;
 	return (!stat (fn, &st) && (st.st_mode & S_IFIFO));

--- a/GUI/xephem/skyhist.c
+++ b/GUI/xephem/skyhist.c
@@ -227,8 +227,7 @@ svh_create (Widget mb_w)
 
 /* called to put up or remove the watch cursor.  */
 void
-svh_cursor (c)
-Cursor c;
+svh_cursor (Cursor c)
 {
 	Window win;
 
@@ -297,9 +296,7 @@ show_entries()
 
 /* using info from hist[i] create its row in the history window */
 static void
-setup_1row (rc_w, i)
-Widget rc_w;
-int i;
+setup_1row (Widget rc_w, int i)
 {
 	Widget f_w, del_w, rep_w, go_w, up_w, down_w, lbl_w, tf_w;
 	Arg args[20];
@@ -403,10 +400,7 @@ int i;
 /* called just as the pulldown menu is cascading */
 /* ARGSUSED */
 static void
-svh_cascading_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_cascading_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i;
 
@@ -442,10 +436,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svh_ltfc_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_ltfc_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i = (long int)client;
 
@@ -457,10 +448,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svh_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "Collects and Installs collections of Sky View settings",
@@ -473,10 +461,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svh_manage_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_manage_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopup (svhshell_w, XtGrabNone);
 	set_something (svhshell_w, XmNiconic, (XtArgVal)False);
@@ -485,10 +470,7 @@ XtPointer call;
 /* callback from the Close PB */
 /* ARGSUSED */
 static void
-svh_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (svhshell_w);
 }
@@ -496,10 +478,7 @@ XtPointer call;
 /* called when the Add button is hit in the history window */
 /* ARGSUSED */
 static void
-svh_add_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_add_cb (Widget w, XtPointer client, XtPointer call)
 {
 	svh_add_current();
 }
@@ -525,10 +504,7 @@ del_i()
  */
 /* ARGSUSED */
 static void
-svh_del_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_del_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* save index */
 	deli = (long int)client;
@@ -562,10 +538,7 @@ rep_i()
  */
 /* ARGSUSED */
 static void
-svh_rep_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_rep_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* save index */
 	repi = (long int)client;
@@ -586,10 +559,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svh_go_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_go_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i = (long int)client;
 	svh_goto (&hist[i].h);
@@ -600,10 +570,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svh_up_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_up_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i = (long int)client;
 	SVHEntry tmp;
@@ -626,10 +593,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-svh_down_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_down_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int i = (long int)client;
 	SVHEntry tmp;
@@ -649,9 +613,7 @@ XtPointer call;
 
 /* setup the label lbl_w from the given SvHistory */
 static void
-setup_label (lbl_w, hp)
-Widget lbl_w;
-SvHistory *hp;
+setup_label (Widget lbl_w, SvHistory *hp)
 {
 	char *projstr = hp->cyl_proj ? "Cyl" : "Sph";
 	char str1[32], str2[32];
@@ -678,10 +640,7 @@ SvHistory *hp;
 /* called when the Save button is hit */
 /* ARGSUSED */
 static void
-svh_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	FILE *histfp;
 	SvHistory *hp;
@@ -733,10 +692,7 @@ XtPointer call;
 /* called when the Load button is hit in the history pulldown */
 /* ARGSUSED */
 static void
-svh_load_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svh_load_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char fn[1024];
 	char buf[1024];
@@ -759,10 +715,7 @@ XtPointer call;
  * some sort of message is also always in msg[].
  */
 static int
-loadhist (histfp, fn, msg)
-FILE *histfp;
-char *fn;
-char *msg;
+loadhist (FILE * histfp, char * fn, char * msg)
 {
 	char buf[1024];
 	char *ulbl;
@@ -895,9 +848,7 @@ char *msg;
  * if opening for write try to create in PrivateDir.
  */
 static FILE *
-openhist(fn, how)
-char *fn;
-char *how;
+openhist(char * fn, char * how)
 {
 	FILE *fp;
 

--- a/GUI/xephem/skyip.c
+++ b/GUI/xephem/skyip.c
@@ -301,8 +301,7 @@ si_off()
  * assigned with magnitude mag.
  */
 void
-si_setPhotomRef (ix, iy, mag)
-double ix, iy, mag;
+si_setPhotomRef (double ix, double iy, double mag)
 {
 	char magstr[32];
 
@@ -321,8 +320,7 @@ double ix, iy, mag;
  * N.B. can be called before we are created
  */
 void
-si_updateGauss (on)
-int on;
+si_updateGauss (int on)
 {
 	if (fimok && on)
 	    si_manage();
@@ -335,8 +333,7 @@ int on;
  * N.B. can be called before we are created
  */
 void
-si_updateGlass (on)
-int on;
+si_updateGlass (int on)
 {
 	/* always close, open only if window already up */
 	si_create();
@@ -348,8 +345,7 @@ int on;
  * N.B. can be called before we are created
  */
 void
-si_updateROI (on)
-int on;
+si_updateROI (int on)
 {
 	/* always close, open only if window already up */
 	si_create();
@@ -361,8 +357,7 @@ int on;
  * N.B. can be called before we are created
  */
 void
-si_updateContrast (on)
-int on;
+si_updateContrast (int on)
 {
 	if (fimok && on)
 	    si_manage();
@@ -375,8 +370,7 @@ int on;
  * N.B. can be called before we are created
  */
 void
-si_updateSlice (on)
-int on;
+si_updateSlice (int on)
 {
 	if (fimok && on)
 	    si_manage();
@@ -389,8 +383,7 @@ int on;
  * we grab the WCS window while we're at it.
  */
 void
-si_cursor (c)
-Cursor c;
+si_cursor (Cursor c)
 {
 	Window win;
 
@@ -422,8 +415,7 @@ si_getFImage ()
 
 /* set the contrast fields in the given FITS header */
 void
-si_setContrast (fip)
-FImage *fip;
+si_setContrast (FImage * fip)
 {
 	int lpix, hpix;
 	int gamma;
@@ -460,13 +452,13 @@ si_ps ()
 
 /* build a pixmap, fpm, from the XImage fim with the given size, flipping and
  * zoom inf, using the current colormap.
+@param w, h;		 screen size 
+@param lr, tb;		 display's flipping 
+@param *zp;		 entire current zoom stack 
+@param nz;			 items on zoom stack 
  */
 void
-si_newPixmap (w, h, lr, tb, zp, nz)
-int w, h;		/* screen size */
-int lr, tb;		/* display's flipping */
-ZM_Undo *zp;		/* entire current zoom stack */
-int nz;			/* items on zoom stack */
+si_newPixmap (int w, int h, int lr, int tb, ZM_Undo * zp, int nz)
 {
 	Display *dsp = XtDisplay (toplevel_w);
 	Window win = XtWindow (toplevel_w);
@@ -565,10 +557,7 @@ int nz;			/* items on zoom stack */
  * last argument determines whether contrast and WCS are set automatically.
  */
 void
-si_newfim (fip, name, autocon)
-FImage *fip;
-char *name;
-int autocon;
+si_newfim (FImage * fip, char * name, int autocon)
 {
 	double eq;
 
@@ -652,9 +641,7 @@ double *imxp, double *imyp)		/* return FITS image coords */
  * return 0 if ok, else fuss with xe_msg and return -1
  */
 static int
-getWCSSeed (wsp, vp)
-WCSSeed *wsp;
-double *vp;
+getWCSSeed (WCSSeed * wsp, double *vp)
 {
 	double v;
 	char *str;
@@ -690,9 +677,7 @@ double *vp;
 
 /* set global fmag/fximoff/fyimoff for given window and image portion */
 static void
-setMag (ww, wh, imx, imy, imw, imh)
-int ww, wh;
-double imx, imy, imw, imh;
+setMag (int ww, int wh, double imx, double imy, double imw, double imh)
 {
 	/* set mag and offsets to display desired portion */
 	fmag = wh/imh;
@@ -712,13 +697,13 @@ double imx, imy, imw, imh;
 /* find a magnification and image offsets to center image such that we always
  * fill the screen, centering and cropping if necessary.
  * in order to establish zoom current context, go through all entries in order.
+@param ww, wh;	 window w/h 
+@param lr, tb;	 user's notion of what is flipped 
+@param *zp;	 zoom info in screen coords, else NULL 
+@param nz;		 n zoom entries 
  */
 static void
-chooseMag (ww, wh, lr, tb, zp, nz)
-int ww, wh;	/* window w/h */
-int lr, tb;	/* user's notion of what is flipped */
-ZM_Undo *zp;	/* zoom info in screen coords, else NULL */
-int nz;		/* n zoom entries */
+chooseMag (int ww, int wh, int lr, int tb, ZM_Undo * zp, int nz)
 {
 	double imx, imy;	/* corner of image to display, im pixels */
 	double imw, imh;	/* size of image to display, im pixels */
@@ -824,8 +809,7 @@ build_colormap()
 
 /* given a FITS pixel, return an X pixel */
 static Pixel
-gray_pixel (fp)
-int fp;
+gray_pixel (int fp)
 {
 	int gp = (int)colormap[fp];
 
@@ -1004,9 +988,7 @@ int lr, int tb)		/* user's flip settings */
 
 /* print stats for glass given image location of center */
 static void
-printGlassStats(rp, ix, iy)
-ImRegion *rp;
-double ix, iy;
+printGlassStats(ImRegion * rp, double ix, double iy)
 {
 	ImStats ims;
 	int cx, cy;
@@ -1030,10 +1012,7 @@ double ix, iy;
  * N.B. may be called before w is realized, eg, glass row set in app defaults.
  */
 static void
-drawGlassRow (w, rp, rx, rw)
-Widget w;
-ImRegion *rp;
-int rx, rw;
+drawGlassRow (Widget w, ImRegion * rp, int rx, int rw)
 {
 	Display *dsp = XtDisplay (w);
 	Window win = XtWindow(w);
@@ -1088,10 +1067,7 @@ int rx, rw;
  * N.B. may be called before w is realized, eg, glass row set in app defaults.
  */
 static void
-drawGlassCol (w, rp, ry, rh)
-Widget w;
-ImRegion *rp;
-int ry, rh;
+drawGlassCol (Widget w, ImRegion * rp, int ry, int rh)
 {
 	Display *dsp = XtDisplay (w);
 	Window win = XtWindow(w);
@@ -1143,8 +1119,7 @@ int ry, rh;
 
 /* print overall image stats */
 static void
-printImageStats(name)
-char *name;
+printImageStats(char * name)
 {
 	char buf[1024];
 	char center[1024];
@@ -1245,8 +1220,7 @@ int lr, int tb)	/* user's flip settings */
 
 /* draw pixels along line from [x0,y0] to [x1,y1] in window of size wwXwh */
 static void
-drawSlice (x0, y0, ww, wh, x1, y1, lr, tb)
-int x0, y0, ww, wh, x1, y1, lr, tb;
+drawSlice (int x0, int y0, int ww, int wh, int x1, int y1, int lr, int tb)
 {
 	Display *dsp = XtDisplay (sda_w);
 	Window win = XtWindow (sda_w);
@@ -1338,8 +1312,7 @@ int lr, int tb)	/* user's flip settings */
  * N.B. must be called after doGlass for gaussian overlays to work.
  */
 static void
-imPhotom (ix, iy)
-double ix, iy;
+imPhotom (double ix, double iy)
 {
 	Display *dsp = XtD;
 	char buf[256], rastr[32], decstr[32], vfwhmstr[32], hfwhmstr[32];
@@ -1488,14 +1461,13 @@ ZM_Undo *zp)
 	XmTextSetString (rstxt_w, buf);
 }
 
-/* draw a nice labeled graph in the given window */
+/* draw a nice labeled graph in the given window 
+@param ww, wh;		 size of win 
+@param xmin, xmax;	 x range 
+@param ymin, ymax;	 y range 
+*/
 static void
-drawGraphGrid (dsp, win, ww, wh, xmin, xmax, ymin, ymax)
-Display *dsp;
-Window win;
-int ww, wh;		/* size of win */
-double xmin, xmax;	/* x range */
-double ymin, ymax;	/* y range */
+drawGraphGrid (Display * dsp, Window win, int ww, int wh, double xmin, double xmax, double ymin, double ymax)
 {
 	double ticks[NTICKS+2];		/* see tickmarks() */
 	XSegment xs[2*(NTICKS+2)];	/* room for both */
@@ -2344,9 +2316,7 @@ si_createdialog()
  * last argument determines whether contrast and WCS are set automatically.
  */
 static void
-si_newImage(name, autocon)
-char *name;
-int autocon;
+si_newImage(char * name, int autocon)
 {
 	double ra, dec;
 
@@ -2407,10 +2377,7 @@ si_ne()
 /* mark refstar on the image */
 /* ARGSUSED */
 static void
-si_markrefstar_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_markrefstar_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!fimok)
 	    xe_msg (1, "First open an image");
@@ -2425,10 +2392,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-si_newrefstar_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_newrefstar_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!fimok)
 	    xe_msg (1, "First open an image");
@@ -2447,10 +2411,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-si_newref_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_newref_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!fimok)
 	    xe_msg (1, "First open an image");
@@ -2466,10 +2427,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-si_managetb_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_managetb_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int state = XmToggleButtonGetState(w);
 	Widget sw = (Widget)client;
@@ -2493,10 +2451,7 @@ XtPointer call;
 
 /* ARGSUSED */
 static void
-si_lohi_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_lohi_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *lostr = XmTextFieldGetString (lo_w);
 	char *histr = XmTextFieldGetString (hi_w);
@@ -2524,10 +2479,7 @@ XtPointer call;
 
 /* ARGSUSED */
 static void
-si_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (si_w);
 }
@@ -2537,10 +2489,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-si_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *tag = (char *)client;
 
@@ -2555,9 +2504,7 @@ XtPointer call;
  * return 0 if ok, else -1 with excuse in msg[]
  */
 static int
-setWCSField (wsp, msg)
-WCSSeed *wsp;
-char msg[];
+setWCSField (WCSSeed * wsp, char msg[])
 {
 	char *kw, *bp, valu[100];
 	double dvalu;
@@ -2596,11 +2543,7 @@ char msg[];
 /* button motion and press/release event handler for the gray map */
 /* ARGSUSED */
 static void
-si_motion_eh (w, client, ev, continue_to_dispatch)
-Widget w;
-XtPointer client;
-XEvent *ev;
-Boolean *continue_to_dispatch;
+si_motion_eh (Widget w, XtPointer client, XEvent * ev, Boolean * continue_to_dispatch)
 {
 	static int moving_lopix;
 	Display *dsp = XtDisplay(w);
@@ -2663,10 +2606,7 @@ Boolean *continue_to_dispatch;
 /* expose callback for the gray map */
 /* ARGSUSED */
 static void
-si_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	Display *dsp = XtDisplay(fda_w);
@@ -2704,10 +2644,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-si_contrast_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_contrast_cb (Widget w, XtPointer client, XtPointer call)
 {
 	void (*pfv)() = (void (*)())client;
 
@@ -2730,10 +2667,7 @@ XtPointer call;
 /* callback from Drag or ValueChanged on the gamma scale */
 /* ARGSUSED */
 static void
-si_gamma_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_gamma_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!fimok)
 	    return;
@@ -2751,10 +2685,7 @@ XtPointer call;
 /* callback for the gray map Inverse Vid TB */
 /* ARGSUSED */
 static void
-si_inv_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_inv_cb (Widget w, XtPointer client, XtPointer call)
 {
 	want_inv = XmToggleButtonGetState(w);
 
@@ -2983,11 +2914,11 @@ makeGlassImage ()
 
 /* fill glass_xim with glasssz (X pixels) view of fim centered at X
  * coords xc,yc. take care at the edges.
+@param xc, yc;	center of glass, in X window coords 
  */
 /* ARGSUSED */
 static void
-fillGlass (xc, yc)
-int xc, yc;	/* center of glass, in X window coords */
+fillGlass (int xc, int yc)
 {
 	int isz = glasssz/glassmag;	/* size of patch image */
 	int x, y, w, h;			/* pixmap patch to extract */
@@ -3161,10 +3092,7 @@ wcsMatch ()
 /* report just how well fim supposedly maps these stars to these image coords.
  */
 static void
-matchStats (fsp, sx, sy, nfs)
-ObjF *fsp;
-double *sx, *sy;
-int nfs;
+matchStats (ObjF * fsp, double * sx, double * sy, int nfs)
 {
 	double m, *med;
 	double sum;
@@ -3228,7 +3156,7 @@ glimsz()
 	return (proper >= MINGLSZ ? proper : MINGLSZ);
 }
 
-
+
 /* WCS dialog stuff
  */
 
@@ -3430,10 +3358,7 @@ si_createwcsdialog()
 
 /* add a Label to a RC */
 static void
-addLabel (rc_w, label, alignment)
-Widget rc_w;
-char *label;
-int alignment;
+addLabel (Widget rc_w, char * label, int alignment)
 {
 	Arg args[20];
 	Widget w;
@@ -3454,10 +3379,7 @@ int alignment;
 
 /* add a PB to a RC */
 static Widget
-addPB (rc_w, str, alignment)
-Widget rc_w;
-char *str;
-int alignment;
+addPB (Widget rc_w, char * str, int alignment)
 {
 	Arg args[20];
 	Widget w;
@@ -3479,10 +3401,7 @@ int alignment;
 
 /* add a TextField to a RC */
 static Widget
-addTF (rc_w, name, rw)
-Widget rc_w;
-char *name;
-int rw;
+addTF (Widget rc_w, char * name, int rw)
 {
 	Arg args[20];
 	Widget w;
@@ -3499,10 +3418,7 @@ int rw;
 
 /* ARGSUSED */
 static void
-si_wcsclose_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_wcsclose_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (wcs_w);
 }
@@ -3510,10 +3426,7 @@ XtPointer call;
 /* called to start a WCS solution */
 /* ARGSUSED */
 static void
-si_wcsgo_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_wcsgo_cb (Widget w, XtPointer client, XtPointer call)
 {
 	watch_cursor (1);
 	wcsMatch ();
@@ -3523,10 +3436,7 @@ XtPointer call;
 /* called to mark seed stars */
 /* ARGSUSED */
 static void
-si_markstars_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_markstars_cb (Widget w, XtPointer client, XtPointer call)
 {
 	double *sx, *sy;
 	int burnt;
@@ -3583,10 +3493,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-si_wcsuse_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_wcsuse_cb (Widget w, XtPointer client, XtPointer call)
 {
 	WCSSeed *wsp = (WCSSeed *)client;
 	char msg[1024];
@@ -3603,10 +3510,7 @@ XtPointer call;
 
 /* ARGSUSED */
 static void
-si_wcshelp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+si_wcshelp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "Pattern match with field stars to find a WCS solution."

--- a/GUI/xephem/skylist.c
+++ b/GUI/xephem/skylist.c
@@ -108,7 +108,7 @@ typedef struct {
 typedef struct {
     char *lname;		/* label widget instance name */
     char *title;		/* sort description */
-    int (*cmp_f)();		/* qsort-style compare function */
+    int (*cmp_f)(const void *, const void *);		/* qsort-style compare function */
     Widget lw;			/* sort-order label widget */
     Widget pw;			/* sort-order pushb widget */
 } SortInfo;
@@ -187,8 +187,7 @@ sl_unmanage()
 
 /* called to put up or remove the watch cursor.  */
 void
-sl_cursor (c)
-Cursor c;
+sl_cursor (Cursor c)
 {
 	Window win;
 
@@ -499,8 +498,7 @@ sl_create_pu()
 
 /* build the sort table in the given XmForm */
 static void
-sl_cr_sorttable(f_w)
-Widget f_w;
+sl_cr_sorttable(Widget f_w)
 {
 	Arg args[20];
 	Widget fr_w;
@@ -565,10 +563,7 @@ Widget f_w;
  */
 /* ARGSUSED */
 static void
-sl_toggle_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_toggle_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int set = XmToggleButtonGetState(w);
 	Widget otherw = (Widget)client;
@@ -579,10 +574,7 @@ XtPointer call;
 /* called when the Close button is hit in the file list prompt */
 /* ARGSUSED */
 static void
-sl_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (list_w);
 }
@@ -590,10 +582,7 @@ XtPointer call;
 /* called when the help button is hit in the file list prompt */
 /* ARGSUSED */
 static void
-sl_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 	    "List and Save Sky View objects in two formats."
@@ -627,10 +616,7 @@ sl_clearlast()
 /* called when the Clear button is hit */
 /* ARGSUSED */
 static void
-sl_clear_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_clear_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* clear all */
 	while (nsortorder)
@@ -640,10 +626,7 @@ XtPointer call;
 /* called when the Undo button is hit */
 /* ARGSUSED */
 static void
-sl_undo_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_undo_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sl_clearlast();
 }
@@ -653,10 +636,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sl_so_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_so_cb (Widget w, XtPointer client, XtPointer call)
 {
 	SortInfo *sip = (SortInfo *)client;
 	char buf[10];
@@ -679,10 +659,7 @@ XtPointer call;
 /* called when the Sort button is hit */
 /* ARGSUSED */
 static void
-sl_sort_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_sort_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sl_sort();
 }
@@ -690,10 +667,7 @@ XtPointer call;
 /* called when the Save button is hit */
 /* ARGSUSED */
 static void
-sl_save_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sl_save_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *fn;
 
@@ -730,10 +704,7 @@ XtPointer call;
 /* called when the Mark button is hit on the popup */
 /* ARGSUSED */
 static void
-slpu_mark_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+slpu_mark_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* sanity check */
 	if (!pu.op)
@@ -745,10 +716,7 @@ XtPointer call;
 /* called when the Delete button is hit on the popup */
 /* ARGSUSED */
 static void
-slpu_del_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+slpu_del_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *txt;
 	int end;
@@ -775,11 +743,7 @@ XtPointer call;
  * used to provide few more options based on text under pointer.
  */
 static void
-sl_info_eh (w, client, ev, continue_to_dispatch)
-Widget w;
-XtPointer client;
-XEvent *ev;
-Boolean *continue_to_dispatch;
+sl_info_eh (Widget w, XtPointer client, XEvent * ev, Boolean * continue_to_dispatch)
 {
 	char objname[MAXNM];
 	DBScan dbs;
@@ -847,8 +811,7 @@ Boolean *continue_to_dispatch;
 
 /* save the text widget in the appropriate file */
 static void
-sl_save (how)
-char *how;
+sl_save (char* how)
 {
 	char *fn = XmToggleButtonGetState(txttb_w)
 			? XmTextFieldGetString (txtfn_w)
@@ -877,8 +840,7 @@ sl_write_qcb ()
 }
 
 static int
-spaceship (diff)
-double diff;
+spaceship (double diff)
 {
 	if (diff < 0)
 	    return (-1);
@@ -1298,9 +1260,7 @@ mastercmp_f (const void *v1, const void *v2)
  * update *dstp and return new final length, sans trailing '\0'.
  */
 static int
-mstrcat (dstp, dl, src, sl)
-char **dstp, *src;
-int dl, sl;
+mstrcat (char ** dstp, int dl, char * src, int sl)
 {
 	char *newdst = XtRealloc (*dstp, sl+dl+1);
 	strcpy (newdst+dl, src);
@@ -1310,9 +1270,7 @@ int dl, sl;
 
 /* fill listt_w with oinfo[noinfo] in ".edb" format */
 static void
-fill_edbfmt (oinfo, noinfo)
-ObjInfo *oinfo;
-int noinfo;
+fill_edbfmt (ObjInfo * oinfo, int noinfo)
 {
 	char *txt = NULL;
 	int txtl = 0;
@@ -1341,9 +1299,7 @@ int noinfo;
 
 /* fill listt_w with oinfo[noinfo] in ".txt" format */
 static void
-fill_txtfmt (oinfo, noinfo)
-ObjInfo *oinfo;
-int noinfo;
+fill_txtfmt (ObjInfo * oinfo, int noinfo)
 {
 	static char dashes[] = "--------------------------";
 	Now *np = mm_get_now();
@@ -1447,8 +1403,7 @@ int noinfo;
  * maintain common background color.
  */
 static void
-sl_colhdr (txt)
-char *txt;
+sl_colhdr (char * txt)
 {
 	Pixel bg;
 	char *nl1, *nl2;

--- a/GUI/xephem/skytoolbar.c
+++ b/GUI/xephem/skytoolbar.c
@@ -649,8 +649,7 @@ static SVTBarItem svtb[] = {
 
 /* search for the SVTBarItem containing the bitmaps bits */
 static SVTBarItem *
-findSVTB (bits)
-unsigned char *bits;
+findSVTB (unsigned char * bits)
 {
 	SVTBarItem *sp;
 
@@ -668,8 +667,7 @@ unsigned char *bits;
  *   current color scheme.
  */
 void
-svtb_newpm (rc_w)
-Widget rc_w;
+svtb_newpm (Widget rc_w)
 {
 	static Pixel last_fg, last_bg;
 	Display *dsp = XtDisplay(toplevel_w);
@@ -722,8 +720,7 @@ Widget rc_w;
 
 /* create top/left/right toolbar controls in the given RowColumn widgets */
 void
-svtb_create (trc_w, lrc_w, rrc_w)
-Widget trc_w, lrc_w, rrc_w;
+svtb_create (Widget trc_w, Widget lrc_w, Widget rrc_w)
 {
 	SVTBarItem *ip;
 	Arg args[20];
@@ -785,8 +782,7 @@ Widget trc_w, lrc_w, rrc_w;
  *   implement image cropping.
  */
 void
-svtb_imMode (on)
-int on;
+svtb_imMode (int on)
 {
 	Widget zi = findSVTB(zoomin_bits)->wid;
 	Widget uz = findSVTB(unzoom_bits)->wid;
@@ -813,80 +809,70 @@ svtb_iszoomok(void)
 
 /* show whether zooming now is ok */
 void
-svtb_zoomok(ok)
-int ok;
+svtb_zoomok(int ok)
 {
 	XtSetSensitive (findSVTB(zoomin_bits)->wid, ok);
 }
 
 /* set whether unzooming now is ok */
 void
-svtb_unzoomok(ok)
-int ok;
+svtb_unzoomok(int ok)
 {
 	XtSetSensitive (findSVTB(unzoom_bits)->wid, ok);
 }
 
 /* call to set the Grid TB */
 void
-svtb_updateGrid (on)
-int on;
+svtb_updateGrid (int on)
 {
 	XmToggleButtonSetState (findSVTB(grid_bits)->wid, on, False);
 }
 
 /* call to set the LR flip TB */
 void
-svtb_updateLRFlip (on)
-int on;
+svtb_updateLRFlip (int on)
 {
 	XmToggleButtonSetState (findSVTB(fliplr_bits)->wid, on, False);
 }
 
 /* call to set the TB flip TB */
 void
-svtb_updateTBFlip (on)
-int on;
+svtb_updateTBFlip (int on)
 {
 	XmToggleButtonSetState (findSVTB(fliptb_bits)->wid, on, False);
 }
 
 /* call to set the Horizon TB */
 void
-svtb_updateHorizon (on)
-int on;
+svtb_updateHorizon (int on)
 {
 	XmToggleButtonSetState (findSVTB(horizon_bits)->wid, on, False);
 }
 
 /* call to set the Field Stars TB */
 void
-svtb_updateFStars (on)
-int on;
+svtb_updateFStars (int on)
 {
 	XmToggleButtonSetState (findSVTB(fstars_bits)->wid, on, False);
 }
 
 /* call to set the Cns TB */
 void
-svtb_updateCns (on)
-int on;
+svtb_updateCns (int on)
 {
 	XmToggleButtonSetState (findSVTB(constel_bits)->wid, on, False);
 }
 
 /* call to set the Automag TB */
 void
-svtb_updateAutoMag (on)
-int on;
+svtb_updateAutoMag (int on)
 {
 	XmToggleButtonSetState (findSVTB(automag_bits)->wid, on, False);
 }
 
 /* call to set the Cyl and Sph projection TBs */
 void
-svtb_updateCyl (on)
-int on;
+svtb_updateCyl (int on)
 {
 	XmToggleButtonSetState (findSVTB(cyl_bits)->wid, on, False);
 	XmToggleButtonSetState (findSVTB(sph_bits)->wid, !on, False);
@@ -894,81 +880,70 @@ int on;
 
 /* call to set the Names TB */
 void
-svtb_updateNames (on)
-int on;
+svtb_updateNames (int on)
 {
 	XmToggleButtonSetState (findSVTB(names_bits)->wid, on, False);
 }
 
 /* call to set the Planes TB */
 void
-svtb_updatePlanes (on)
-int on;
+svtb_updatePlanes (int on)
 {
 	XmToggleButtonSetState (findSVTB(planes_bits)->wid, on, False);
 }
 
 /* call to set the MagScale TB */
 void
-svtb_updateMagScale (on)
-int on;
+svtb_updateMagScale (int on)
 {
 	XmToggleButtonSetState (findSVTB(magscale_bits)->wid, on, False);
 }
 
 /* call to set the LiveReport TB */
 void
-svtb_updateReport (on)
-int on;
+svtb_updateReport (int on)
 {
 	XmToggleButtonSetState(findSVTB(report_bits)->wid, on, False);
 }
 
 /* call to set the Slice TB */
 void
-svtb_updateSlice (on)
-int on;
+svtb_updateSlice (int on)
 {
 	XmToggleButtonSetState (findSVTB(slice_bits)->wid, slice_on=on, False);
 }
 
 /* call to set the ROI TB */
 void
-svtb_updateROI (on)
-int on;
+svtb_updateROI (int on)
 {
 	XmToggleButtonSetState (findSVTB(roi_bits)->wid, roi_on=on, False);
 }
 
 /* call to set the Gauss TB */
 void
-svtb_updateGauss (on)
-int on;
+svtb_updateGauss (int on)
 {
 	XmToggleButtonSetState(findSVTB(gauss_bits)->wid, gauss_on=on, False);
 }
 
 /* call to set the Contrast TB */
 void
-svtb_updateContrast (on)
-int on;
+svtb_updateContrast (int on)
 {
 	XmToggleButtonSetState(findSVTB(contrast_bits)->wid, contrast_on=on, 0);
 }
 
 /* call to set the Glass TB */
 void
-svtb_updateGlass (on)
-int on;
+svtb_updateGlass (int on)
 {
 	XmToggleButtonSetState(findSVTB(glass_bits)->wid, glass_on=on, False);
 }
 
 /* call to set the Class and Solsys TB according to svf filter tables */
 void
-svtb_updateCTTT(ct, tt)
-char ct[NCLASSES];
-char tt[NOBJTYPES];
+svtb_updateCTTT(char ct[NCLASSES], char tt[NOBJTYPES])
 {
 	int i, j;
 
@@ -1051,10 +1026,7 @@ svtb_gaussIsOn()
  * client is ct list.
  */
 static void
-svtb_ct_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_ct_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int set = XmToggleButtonGetState(w);
 	char *types = (char *)client;
@@ -1081,10 +1053,7 @@ XtPointer call;
  * client is tt list.
  */
 static void
-svtb_tt_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_tt_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int set = XmToggleButtonGetState(w);
 	ObjType_t *types = (ObjType_t *)client;
@@ -1107,10 +1076,7 @@ XtPointer call;
  * activate the Cyl TB to the opposite state.
  */
 static void
-svtb_sph_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_sph_cb (Widget w, XtPointer client, XtPointer call)
 {
 	SVTBarItem *ip = findSVTB (cyl_bits);
 
@@ -1121,10 +1087,7 @@ XtPointer call;
  * slace the Sph TB to the opposite state.
  */
 static void
-svtb_cyl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_cyl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	SVTBarItem *ip = findSVTB (sph_bits);
 
@@ -1135,20 +1098,14 @@ XtPointer call;
  * client is addr of int to set.
  */
 static void
-svtb_toggle_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_toggle_cb (Widget w, XtPointer client, XtPointer call)
 {
 	*(int *)client = XmToggleButtonGetState(w);
 }
 
 /* monument toggle */
 static void
-svtb_monument_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_monument_cb (Widget w, XtPointer client, XtPointer call)
 {
 	monument_on = XmToggleButtonGetState(w);
 	if (si_ison())
@@ -1157,10 +1114,7 @@ XtPointer call;
 
 /* contrast toggle */
 static void
-svtb_contrast_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_contrast_cb (Widget w, XtPointer client, XtPointer call)
 {
 	contrast_on = XmToggleButtonGetState(w);
 	si_updateContrast(contrast_on);
@@ -1168,10 +1122,7 @@ XtPointer call;
 
 /* glass toggle */
 static void
-svtb_glass_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_glass_cb (Widget w, XtPointer client, XtPointer call)
 {
 	glass_on = XmToggleButtonGetState(w);
 	si_updateGlass(glass_on);
@@ -1179,10 +1130,7 @@ XtPointer call;
 
 /* roi toggle */
 static void
-svtb_roi_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_roi_cb (Widget w, XtPointer client, XtPointer call)
 {
 	roi_on = XmToggleButtonGetState(w);
 	si_updateROI(roi_on);
@@ -1190,10 +1138,7 @@ XtPointer call;
 
 /* gauss toggle */
 static void
-svtb_gauss_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_gauss_cb (Widget w, XtPointer client, XtPointer call)
 {
 	gauss_on = XmToggleButtonGetState(w);
 	si_updateGauss(gauss_on);
@@ -1201,10 +1146,7 @@ XtPointer call;
 
 /* slice toggle */
 static void
-svtb_slice_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_slice_cb (Widget w, XtPointer client, XtPointer call)
 {
 	slice_on = XmToggleButtonGetState(w);
 	si_updateSlice(slice_on);

--- a/GUI/xephem/skyviewmenu.c
+++ b/GUI/xephem/skyviewmenu.c
@@ -498,9 +498,7 @@ sv_ison()
  */
 /* ARGSUSED */
 void
-sv_update (np, how_much)
-Now *np;
-int how_much;
+sv_update (Now * np, int how_much)
 {
         if (!svshell_w || !sv_pm)
 	    return;
@@ -534,8 +532,7 @@ sv_scopeMark (Obj *op)
  * make sure no pending trail creations can come in and do something.
  */
 void
-sv_newdb(appended)
-int appended;
+sv_newdb(int appended)
 {
 	if (!appended) {
 	    tobj_newdb();
@@ -637,8 +634,7 @@ sv_viewupres()
  * mimic si_newPixmap's cropping behavior.
  */
 static void
-setImFOVScales (fip)
-FImage *fip;
+setImFOVScales (FImage * fip)
 {
 	double ra1, dec1, ra2, dec2, cvfov, vfov;
 
@@ -660,9 +656,7 @@ FImage *fip;
  *   no need for X stuff to draw a little on the sky view window.
  */
 void
-sv_drawimdot (ix, iy, rad, color)
-double ix, iy;
-int rad, color;
+sv_drawimdot (double ix, double iy, int rad, int color)
 {
 	static Pixel *colrs[] = {&eq_p, &cnsfig_p, &grid_p};
 	Display *dsp = XtDisplay (svda_w);
@@ -845,10 +839,7 @@ sv_amagoff ()
 
 /* called when the toolbar "brighter" PB is hit */
 void
-svtb_brighter_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_brighter_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int stmag, ssmag, dsmag, magstp;
 
@@ -865,10 +856,7 @@ XtPointer call;
  * client is 0 for l/r, else 1 for t/b
  */
 void
-svtb_flip_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_flip_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int tb = (long int)client;
 
@@ -880,10 +868,7 @@ XtPointer call;
 
 /* called when the toolbar "constel" TB changes */
 void
-svtb_constel_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_constel_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int want_conb_atoff = -1;	/* flag as uninitialized */
 	static int want_conf_atoff;
@@ -926,10 +911,7 @@ XtPointer call;
 
 /* called when the toolbar "dimmer" PB is hit */
 void
-svtb_dimmer_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_dimmer_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int stmag, ssmag, dsmag, magstp;
 
@@ -944,10 +926,7 @@ XtPointer call;
 
 /* called when the toolbar "grid" TB changes */
 void
-svtb_grid_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_grid_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int onnow = XmToggleButtonGetState(grid_w);
 
@@ -965,10 +944,7 @@ XtPointer call;
 
 /* called when the toolbar "automag" TB changes */
 void
-svtb_automag_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_automag_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (wantamag_w,
 				    !XmToggleButtonGetState(wantamag_w), True);
@@ -976,20 +952,14 @@ XtPointer call;
 
 /* called when the toolbar "horizon" TB changes */
 void
-svtb_hzn_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_hzn_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (hznmap_w, !XmToggleButtonGetState(hznmap_w), 1);
 }
 
 /* called when the toolbar "live report" TB changes */
 void
-svtb_report_cb(w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_report_cb(Widget w, XtPointer client, XtPointer call)
 {
 	want_report = XmToggleButtonGetState(w);
 	XmToggleButtonSetState (wantreport_w, want_report, 1);
@@ -998,20 +968,14 @@ XtPointer call;
 
 /* called when the toolbar "field stars" TB is hit */
 void
-svtb_fstars_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_fstars_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (wantfs_w, !XmToggleButtonGetState(wantfs_w), 1);
 }
 
 /* called when the toolbar "names" TB changes */
 void
-svtb_names_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_names_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int lbl_lst_atoff = -1;		/* flag as uninitialized */
 	static int lbl_lfs_atoff;
@@ -1075,10 +1039,7 @@ svtb_reportIsOn()
 
 /* called when the toolbar "planes" TB changes */
 void
-svtb_planes_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_planes_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int want_eq_atoff = -1;		/* flag as uninitialized */
 	static int want_ga_atoff;
@@ -1116,20 +1077,14 @@ XtPointer call;
 
 /* called when the toolbar "magscale" TB changes */
 void
-svtb_magscale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_magscale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (wantmag_w, XmToggleButtonGetState(w), True);
 }
 
 /* called when the toolbar "orient" TB changes */
 void
-svtb_orient_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_orient_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (aa_mode)
 	    XmToggleButtonSetState (rad_w, True, True);
@@ -1139,30 +1094,21 @@ XtPointer call;
 
 /* called when the toolbar "cylindrical projection" TB is hit */
 void
-svtb_proj_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_proj_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (sph_w, !XmToggleButtonGetState(w), True);
 }
 
 /* called when the toolbar "print" PB is hit */
 void
-svtb_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XPSAsk ("Sky View", sv_print);
 }
 
 /* called when the toolbar "zoom in" PB is hit */
 void
-svtb_zoomin_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_zoomin_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* asserts */
 	if (zm_cundo < 0) {
@@ -1197,10 +1143,7 @@ XtPointer call;
 
 /* called when the toolbar "unzoom" PB is hit */
 void
-svtb_unzoom_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+svtb_unzoom_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* asserts */
 	if (!zm_undo || zm_cundo <= 0) {
@@ -1247,8 +1190,7 @@ svtb_sync()
  * N.B. we do *not* update the s_ fields of op.
  */
 void
-sv_point (op)
-Obj *op;
+sv_point (Obj * op)
 {
 	if (!sv_ison() || !op || op->o_type == UNDEFOBJ)
 	    return;
@@ -1263,8 +1205,7 @@ Obj *op;
  * N.B. we do *not* update the s_ fields of op.
  */
 void
-sv_id (op)
-Obj *op;
+sv_id (Obj * op)
 {
 	if (!sv_ison() || !op || op->o_type == UNDEFOBJ)
 	    return;
@@ -1274,8 +1215,7 @@ Obj *op;
 
 /* called to put up or remove the watch cursor.  */
 void
-sv_cursor (c)
-Cursor c;
+sv_cursor (Cursor c)
 {
 	Window win;
 
@@ -1299,8 +1239,7 @@ Cursor c;
 /* draw everything subject to any filtering.
  */
 void
-sv_all(np)
-Now *np;
+sv_all(Now * np)
 {
 	Display *dsp = XtDisplay(svda_w);
 	/* N.B. don't cache sv_pm, it can change if resized vis XmUpdate */
@@ -2138,13 +2077,7 @@ sv_drawComet (XArc xfa[], int diam, int x, int y)
 
 /* draw the planet at [x,y] with diameter d showing proper phase */
 static void
-sv_draw_pl (dsp, win, gc, op, x, y, d)
-Display *dsp;
-Drawable win;
-GC gc;
-Obj *op;
-int x, y;
-int d;
+sv_draw_pl (Display * dsp, Drawable win, GC gc, Obj * op, int x, int y, int d)
 {
 	double f = op->s_phase/100.0;	/* fraction lit */
 	int x0 = x-d/2, y0 = y-d/2;	/* corner of moon bounding box */
@@ -2216,10 +2149,7 @@ sv_getfldstars (ObjF **fspp, int *nfsp)
  * return 0 if ok else -1.
  */
 static int
-sv_mktrail (ts, statep, client)
-TrTS ts[];
-TrState *statep;
-XtPointer client;
+sv_mktrail (TrTS ts[], TrState * statep, XtPointer client)
 {
 	Obj *trop = (Obj *)client;
 	TrailObj *top;
@@ -2291,8 +2221,7 @@ XtPointer client;
 
 /* helper function to fill in the Help menu*/
 static void
-sv_fillin_help (mb_w)
-Widget mb_w;
+sv_fillin_help (Widget mb_w)
 {
 	typedef struct {
 	    char *label;	/* what goes on the help label */
@@ -2344,8 +2273,7 @@ Widget mb_w;
 
 /* helper function to fill in the menubar */
 static void
-sv_fillin_mb (mb_w)
-Widget mb_w;
+sv_fillin_mb (Widget mb_w)
 {
 	Widget cb_w, pd_w;
 	Widget w;
@@ -3374,8 +3302,7 @@ load_deffig (Widget om)
 
 /* helper func to make all the "grid" controls in the given form */
 static void
-sv_create_grid_option (f_w)
-Widget f_w;
+sv_create_grid_option (Widget f_w)
 {
 	Arg args[20];
 	int n;
@@ -3516,8 +3443,7 @@ Widget f_w;
 
 /* helper function to create the labeling controls in the Options dialog */
 static void
-sv_create_op_lbl (rc_w)
-Widget rc_w;
+sv_create_op_lbl (Widget rc_w)
 {
 	static ViewOpt lblnbr[] = {
 	    /* these are TB/TB/Scale triples */
@@ -3669,10 +3595,7 @@ Widget rc_w;
 /* callback from selecting the Close PB in the Options control. */
 /* ARGSUSED */
 static void
-sv_closeopdialog_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_closeopdialog_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (svops_w);
 }
@@ -3680,10 +3603,7 @@ XtPointer call;
 /* callback from selecting the Options control. */
 /* ARGSUSED */
 static void
-sv_opdialog_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_opdialog_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!XtIsManaged(svops_w))
 	    XtManageChild (svops_w);
@@ -3693,8 +3613,7 @@ XtPointer call;
  * empty for now, filled when cascades
  */
 static void
-sv_create_favmenu (parent)
-Widget parent;
+sv_create_favmenu (Widget parent)
 {
 	Arg args[20];
 	Widget pd_w, cb_w;
@@ -3718,10 +3637,7 @@ Widget parent;
 /* callback from the main Close button */
 /* ARGSUSED */
 static void
-sv_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do all the work */
 	XtPopdown (svshell_w);
@@ -3732,10 +3648,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (svops_w);
 	sl_unmanage ();
@@ -3761,10 +3674,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This displays all database objects currently in memory onto the sky. The view",
@@ -3781,10 +3691,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -3794,10 +3701,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_cyl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_cyl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonCallbackStruct *sp = (XmToggleButtonCallbackStruct *)call;
 	int cyl = (w == cyl_w);
@@ -3828,10 +3732,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_aa_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_aa_cb (Widget w, XtPointer client, XtPointer call)
 {
 #define	POLEERR		degrad(90 - 1.0/3600.0)	/* polar ambiguous area */
 	XmToggleButtonCallbackStruct *sp = (XmToggleButtonCallbackStruct *)call;
@@ -3900,10 +3801,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_filter_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_filter_cb (Widget w, XtPointer client, XtPointer call)
 {
 	svf_manage();
 }
@@ -3913,10 +3811,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_fits_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_fits_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sf_manage();
 }
@@ -3926,10 +3821,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_image_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_image_cb (Widget w, XtPointer client, XtPointer call)
 {
 	si_manage();
 }
@@ -3938,10 +3830,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_registration_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_registration_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ir_manage();
 }
@@ -3951,10 +3840,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_wcs_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_wcs_cb (Widget w, XtPointer client, XtPointer call)
 {
 	siwcs_manage();
 }
@@ -3963,10 +3849,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_addframe_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_addframe_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (sv_pm, dt_w);
 }
@@ -3976,10 +3859,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_list_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_list_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sl_manage();
 }
@@ -3989,10 +3869,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_gt_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_gt_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Widget pw = (Widget)client;
 
@@ -4005,10 +3882,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_grid_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_grid_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int state = XmToggleButtonGetState(w);
 	int *wantp = (int *)client;
@@ -4034,10 +3908,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_brs_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_brs_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sv_all(mm_get_now());
 }
@@ -4045,10 +3916,7 @@ XtPointer call;
 /* callback from RETURN in either grid size TF */
 /* ARGSUSED */
 static void
-sv_gridtf_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_gridtf_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* turns off Auto as a side effect */
 	XmToggleButtonSetState (autogrid_w, want_autogrid = False, True);
@@ -4061,10 +3929,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_mancoord_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_mancoord_cb (Widget w, XtPointer client, XtPointer call)
 {
 	cc_manage();
 }
@@ -4073,10 +3938,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XPSAsk ("Sky View", sv_print);
 }
@@ -4121,8 +3983,7 @@ sv_print ()
 }
 
 static void
-sv_ps_annotate (np)
-Now *np;
+sv_ps_annotate (Now * np)
 {
 	double alt, az, ra, dec;
 	double fov;
@@ -4351,10 +4212,7 @@ Now *np;
  */
 /* ARGSUSED */
 static void
-sv_track_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_track_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (!XmToggleButtonGetState (w)) {
 	    track_op = (Obj *)0;
@@ -4367,9 +4225,7 @@ XtPointer call;
  * also possibly reset any unzoom records.
  */
 static void
-sv_set_scale(which, cutzoom)
-int which;
-int cutzoom;
+sv_set_scale(int which, int cutzoom)
 {
 	Arg args[20];
 	char buf[64];
@@ -4450,8 +4306,7 @@ int cutzoom;
  * N.B. might be called before first expose when we don't yet know sv_h
  */
 static void
-sv_set_fov(vfov)
-double vfov;
+sv_set_fov(double vfov)
 {
 	if (vfov > degrad(180.))
 	    vfov = degrad(180.);
@@ -4467,11 +4322,7 @@ double vfov;
  */
 /* ARGSUSED */
 static void
-sv_da_exp_cb (w, client,
-call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	Display *dsp = XtDisplay(svda_w);
@@ -4546,8 +4397,7 @@ XtPointer call;
  * try to keep all on screen too.
  */
 static void
-sv_resize (neww, newh)
-int neww, newh;
+sv_resize (int neww, int newh)
 {
 	Display *dsp = XtDisplay(svda_w);
 	int dspw = DisplayWidth(dsp, DefaultScreen(dsp)) - 100;	 /* fudge */
@@ -4614,9 +4464,7 @@ int neww, newh;
 
 /* draw the magnitude scale, based on the near-sky setting */
 static void
-sv_magscale (dsp, win)
-Display *dsp;
-Window win;
+sv_magscale (Display * dsp, Window win)
 {
 	int cw, ch;		/* w and h of typical digit */
 	int x0, y0;		/* ul corner of box */
@@ -4713,11 +4561,7 @@ sv_copy_sky()
 /* called when there is mouse activity over the drawing area */
 /* ARGSUSED */
 static void
-sv_da_ptr_eh (w, client, ev, continue_to_dispatch)
-Widget w;
-XtPointer client;
-XEvent *ev;
-Boolean *continue_to_dispatch;
+sv_da_ptr_eh (Widget w, XtPointer client, XEvent *ev, Boolean * continue_to_dispatch)
 {
 	Now *np = mm_get_now();
 	Display *dsp = XtDisplay(w);
@@ -5046,10 +4890,7 @@ sv_pick (XEvent *ev, int wx, int wy)
  */
 /* ARGSUSED */
 static void
-sv_scale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_scale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScaleCallbackStruct *s = (XmScaleCallbackStruct *)call;
 	int which = (long int) client;
@@ -5105,10 +4946,7 @@ sv_loadcnsfigs_cb (Widget w, XtPointer client, XtPointer call)
  */
 /* ARGSUSED */
 static void
-sv_lbln_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_lbln_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int *lp = (int *)client;
 
@@ -5130,10 +4968,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_lblm_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_lblm_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int *lp = (int *)client;
 
@@ -5155,10 +4990,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_option_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_option_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int *p = (int *)client;
 
@@ -5225,10 +5057,7 @@ XtPointer call;
 /* called to bring up the eyepiece control dialog */
 /* ARGSUSED */
 static void
-sv_eyep_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_eyep_cb (Widget w, XtPointer client, XtPointer call)
 {
 	se_manage();
 }
@@ -5236,10 +5065,7 @@ XtPointer call;
 /* called to bring up the binary star orbit map */
 /* ARGSUSED */
 static void
-sv_bsmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_bsmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	svbs_manage(pu.op);
 }
@@ -5250,10 +5076,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_faving_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_faving_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj **favs;
 	int nfavs = fav_get_loaded (&favs);
@@ -5288,10 +5111,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_fav_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_fav_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XEvent *ev = ((XmAnyCallbackStruct*)call)->event;
 	Obj **favs, *op;
@@ -5329,8 +5149,7 @@ XtPointer call;
  * real value.
  */
 static void
-sv_read_scale (which)
-int which;
+sv_read_scale (int which)
 {
 	int i;
 
@@ -5359,8 +5178,7 @@ int which;
  * set force to disregard tests for stable conditions.
  */
 void
-sv_loadfs(force)
-int force;
+sv_loadfs(int force)
 {
 	static double lcfov, lcazra, lcaltdec;		/* last call */
 	static double lsmjd, lsfov, lsra, lsdec;	/* last shown */
@@ -5443,10 +5261,7 @@ int force;
 
 /* make sure trk_pm is at least minw x minh */
 static void
-sv_track_pm (dsp, win, minw, minh)
-Display *dsp;
-Window win;
-int minw, minh;
+sv_track_pm (Display * dsp, Window win, int minw, int minh)
 {
 	Window root;
 	unsigned int bw, d;
@@ -5473,10 +5288,7 @@ int minw, minh;
  *   just copying sv_pm to svda_w again.
  */
 static void
-sv_draw_report_coords (new, sep, winx, winy, altdec, azra)
-int new, sep;
-int winx, winy;
-double altdec, azra;
+sv_draw_report_coords (int new, int sep, int winx, int winy, double altdec, double azra)
 {
 #define	NTLAB		12			/* /even/ number of labels */
 	static double start_altdec, start_azra;	/* angular reference */
@@ -5727,10 +5539,7 @@ double altdec, azra;
 
 /* draw the transient window marker at [x,y] using sv_tmgc */
 static void
-sv_drawtm (dsp, win, x, y)
-Display *dsp;
-Window win;
-int x, y;
+sv_drawtm (Display * dsp, Window win, int x, int y)
 {
 	int diag = 707*MARKR/1000;
 
@@ -5747,10 +5556,7 @@ int x, y;
 
 /* draw the stickier pixmap marker at [x,y] using sv_gc */
 static void
-sv_drawm (dsp, pm, x, y)
-Display *dsp;
-Pixmap pm;
-int x, y;
+sv_drawm (Display * dsp, Pixmap pm, int x, int y)
 {
 	int diag = 707*MARKR/1000;
 
@@ -5766,16 +5572,15 @@ int x, y;
  * return 0 if did all that was asked else generate a message using xe_msg(*,1)
  *   and return -1.
  * N.B. we do *not* update the s_ fields of op.
+@param in_center;	 whether to center an object already within the fov 
+@param out_center;	 whether to center an object not already within the fov 
+@param mark;	whether to mark the object if it ends up visible 
+@param xemsg;	whether to issue an xe_msg if object is out of view 
+@param use_window;	 write directly to the window, not the pixmap (for speed) 
+@param newfov;	 new fov if other conditions met. leave unchanged if == 0 
  */
 static int
-sv_mark (op, in_center, out_center, mark, xemsg, use_window, newfov)
-Obj *op;
-int in_center;	/* whether to center an object already within the fov */
-int out_center;	/* whether to center an object not already within the fov */
-int mark;	/* whether to mark the object if it ends up visible */
-int xemsg;	/* whether to issue an xe_msg if object is out of view */
-int use_window;	/* write directly to the window, not the pixmap (for speed) */
-double newfov;	/* new fov if other conditions met. leave unchanged if == 0 */
+sv_mark (Obj * op, int in_center, int out_center, int mark, int xemsg, int use_window, double newfov)
 {
 	Display *dsp = XtDisplay (svda_w);
 	Window win = XtWindow (svda_w);
@@ -5874,10 +5679,7 @@ double newfov;	/* new fov if other conditions met. leave unchanged if == 0 */
  * it goes down by itself.
  */
 static void
-sv_popup (ev, op, tsp)
-XEvent *ev;
-Obj *op;
-TSky *tsp;
+sv_popup (XEvent * ev, Obj * op, TSky * tsp)
 {
 	Now *np = mm_get_now();
 	char buf[32], buf2[64];
@@ -6534,8 +6336,7 @@ sv_create_popup()
 
 /* create the zoom cascade menu off pulldown menu pd_w */
 static void
-sv_create_zoomcascade (pd_w)
-Widget pd_w;
+sv_create_zoomcascade (Widget pd_w)
 {
 	Widget cb_w, zpd_w, w;
 	Arg args[20];
@@ -6584,8 +6385,7 @@ Widget pd_w;
 
 /* create the label l/r cascade menu off pulldown menu pd_w */
 static void
-sv_create_labellr (pd_w)
-Widget pd_w;
+sv_create_labellr (Widget pd_w)
 {
 	Widget lpd_w;
 	Arg args[20];
@@ -6627,10 +6427,7 @@ Widget pd_w;
  */
 /* ARGSUSED */
 static void
-sv_pu_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_pu_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int code = (long int)client;
 	Obj *op = pu.tsp ? &pu.tsp->o : pu.op;
@@ -6716,10 +6513,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_pu_zoom_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_pu_zoom_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int factor = (long int)client;
 	double newfov = sv_vfov*10.0/factor;
@@ -6737,10 +6531,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_pu_trail_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+sv_pu_trail_cb (Widget wid, XtPointer client, XtPointer call)
 {
 	TrailObj *top = tobj_find (pu.op);
 
@@ -6770,10 +6561,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_pu_label_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+sv_pu_label_cb (Widget wid, XtPointer client, XtPointer call)
 {
 	int set = ((XmToggleButtonCallbackStruct *)call)->set;
 	int side = (long int)client;
@@ -6798,10 +6586,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_pu_track_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_pu_track_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (XmToggleButtonGetState (w)) {
 	    track_op = pu.op;
@@ -6816,11 +6601,7 @@ XtPointer call;
  * SVScut(a,x) where a selects what and x is a factor.
  */
 static void
-sv_shortcuts (w, e, p, n)
-Widget w;
-XEvent *e;
-String *p;
-Cardinal *n;
+sv_shortcuts (Widget w, XEvent * e, String * p, Cardinal *n)
 {
 	int what;
 	double factor;
@@ -6890,8 +6671,7 @@ tobj_rmoff()
  * it's no big deal if op isn't really on any trail list.
  */
 static void
-tobj_rmobj (op)
-Obj *op;
+tobj_rmobj (Obj * op)
 {
 	TrailObj **topp;	/* address to be changed if we decide to 
 				 * remove *topp
@@ -6923,9 +6703,7 @@ Obj *op;
  * (we never return if there's no memory)
  */
 static TrailObj *
-tobj_addobj (op, nsky)
-Obj *op;
-int nsky;
+tobj_addobj (Obj * op, int nsky)
 {
 	TrailObj *top;
 	int nbytes;
@@ -6988,8 +6766,7 @@ tobj_newdb()
  * return NULL if don't find it.
  */
 static TrailObj *
-tobj_find (op)
-Obj *op;
+tobj_find (Obj * op)
 {
 	TrailObj *top;
 
@@ -7154,9 +6931,7 @@ sv_dbobjloc (Obj *op, int *xp, int *yp, int *dp)
  * N.B. we take care to not change the tsp->o in any way.
  */
 static int
-sv_trailobjloc (tsp, xp, yp)
-TSky *tsp;
-int *xp, *yp;
+sv_trailobjloc (TSky * tsp, int * xp, int * yp)
 {
 	Obj *op = &tsp->o;
 	double altdec, azra;
@@ -7172,8 +6947,7 @@ int *xp, *yp;
  * return 0 if we know it's definitely not on screen, or 1 if it might be.
  */
 static int
-sv_precheck (op)
-Obj *op;
+sv_precheck (Obj * op)
 {
 	Now *np = mm_get_now();
 
@@ -7253,12 +7027,12 @@ sv_onscrn (Now *np, Obj *op)
 /* compute x/y loc of a point at azra/altdec as viewed from sv_azra/sv_altdec.
  * if we are displaying a FITS image, use it directly.
  * always set *x/yp, but return value is whether it is really on screen now.
+@param altdec;	 angle up from spherical equator, such as alt or dec; rads 
+@param azra;	 angle around spherical pole, such as az or ra; rads 
+@param *xp, *yp;	 return X coords within sv_w/h window *
  */
 static int
-sv_loc (altdec, azra, xp, yp)
-double altdec;	/* angle up from spherical equator, such as alt or dec; rads */
-double azra;	/* angle around spherical pole, such as az or ra; rads */
-int *xp, *yp;	/* return X coords within sv_w/h window */
+sv_loc (double altdec, double azra, int * xp, int * yp)
 {
 	if (si_ison()) {
 	    /* use FITS image */
@@ -7392,12 +7166,12 @@ int *xp, *yp;	/* return X coords within sv_w/h window */
 /* compute azra/altdec loc of a point at x/y as viewed from sv_azra/sv_altdec.
  * if displaying a FITS image, use it directly.
  * return true if x/y is valid, else 0.
+@param x, y;	 X coords within window 
+@param *altdecp; angle up from spherical equator, such as alt or dec; rad 
+@param *azrap;	 angle around spherical pole, such as az or ra; rad 
  */
 static int
-sv_unloc (x, y, altdecp, azrap)
-int x, y;	/* X coords within window */
-double *altdecp;/* angle up from spherical equator, such as alt or dec; rad */
-double *azrap;	/* angle around spherical pole, such as az or ra; rad */
+sv_unloc (int x, int y, double * altdecp, double * azrap)
 {
 	/* basic bounds check */
 	if (x < 0 || x >= sv_w || y < 0 || y >= sv_h)
@@ -7523,12 +7297,7 @@ sv_other (double altdec, double azra, int aa, double *altdecp, double *azrap)
  * display mode, else all values will be geocentric.
  */
 static void
-sv_fullwhere (np, altdec, azra, aa, altp, azp, rap, decp)
-Now *np;
-double altdec, azra;
-int aa;
-double *altp, *azp;
-double *rap, *decp;
+sv_fullwhere (Now * np, double altdec, double azra, int aa, double *altp, double *azp, double *rap, double *decp)
 {
 	double ha;
 	double lst;
@@ -7652,9 +7421,7 @@ labelSide(OneObj *oop, Region lr, int cw, int ch, XRectangle *xrp, int lblflags)
 
 /* draw all visible objects */
 static void
-draw_allobjs (dsp, win)
-Display *dsp;
-Drawable win;
+draw_allobjs (Display * dsp, Drawable win)
 {
 #define NOPMEM		4096
 	OneObjList oplist[DrawLblNb];	/* objects on screen, by category */
@@ -7811,10 +7578,7 @@ Drawable win;
  * all angles in rads.
  */
 static void
-niceStep (a, dp, np)
-double a;
-double *dp;
-int *np;
+niceStep (double a, double * dp, int *np)
 {
 	static int nicesecs[] = {
 	       1,    2,     5,    10,    20,     30,
@@ -7835,17 +7599,15 @@ int *np;
 	*dp = d;
 }
 
-/* draw label on grid near [x,y] */
+/* draw label on grid near [x,y] 
+@param ad, ar;		 location known to be at intersection
+@param x0, y0;		 location known to be at intersection
+@param samesys;		 whether grid is in same coord system as display 
+@param arlabel;		 whether want azra or altdec label 
+@param dv, dh;		 altdec and azra whole grid step sizes, rads 
+*/
 static void
-draw_grid_label (dsp, win, gc, ad, ar, x0, y0, samesys, arlabel, dv, dh)
-Display *dsp;
-Window win;
-GC gc;
-double ad, ar;		/* location known to be at intersection*/
-int x0, y0;		/* location known to be at intersection*/
-int samesys;		/* whether grid is in same coord system as display */
-int arlabel;		/* whether want azra or altdec label */
-double dv, dh;		/* altdec and azra whole grid step sizes, rads */
+draw_grid_label (Display * dsp, Window win, GC gc, double ad, double ar, int x0, int y0, int samesys, int arlabel, double dv, double dh)
 {
 	char buf[32];		/* coord string */
 	double a;		/* text rotation angle */
@@ -7891,10 +7653,7 @@ double dv, dh;		/* altdec and azra whole grid step sizes, rads */
 
 /* draw a nice grid, with labels */
 static void
-draw_grid(dsp, win, gc)
-Display *dsp;
-Window win;
-GC gc;
+draw_grid(Display * dsp, Window win, GC gc)
 {
 	XSegment xsegs[50], *xs;/* segments cache */
 	int samesys;		/* whether grid is in same coord sys as dsp */
@@ -8078,11 +7837,7 @@ GC gc;
 /* draw the horizon map.
  */
 static void
-draw_hznmap (np, dsp, win, gc)
-Now *np;
-Display *dsp;
-Window win;
-GC gc;
+draw_hznmap (Now * np, Display * dsp, Window win, GC gc)
 {
 	if (cyl_proj && aa_mode)
 	    draw_hznac (dsp, win, gc);
@@ -8095,10 +7850,7 @@ GC gc;
  * vertical dimension of the screen.
  */
 static void
-draw_hznac (dsp, win, gc)
-Display *dsp;
-Window win;
-GC gc;
+draw_hznac (Display * dsp, Window win, GC gc)
 {
 #define	UNIVLEN	2	/* points for wrap around the universe */
 	XPoint *xpts;
@@ -8150,10 +7902,7 @@ GC gc;
  * if !cyl_proj then only the horizon border is drawn
  */ 
 static void
-draw_hznother (dsp, win, gc)
-Display *dsp;
-Window win;
-GC gc;
+draw_hznother (Display * dsp, Window win, GC gc)
 {
 #define	UNIVLEN	2	/* points for wrap around the universe */
 	int wx, lx;
@@ -8269,10 +8018,7 @@ GC gc;
 
 /* draw the horizon profile in any mode */
 static void
-draw_hznProfile (dsp, win, gc)
-Display *dsp;
-Window win;
-GC gc;
+draw_hznProfile (Display * dsp, Window win, GC gc)
 {
 	int lx, ly, lv;
 	int sv_w_eff = sv_w;
@@ -8358,9 +8104,7 @@ sv_hznOpOk (Obj *op)
 
 /* draw compass */
 static void
-draw_compass (dsp, win)
-Display *dsp;
-Drawable win;
+draw_compass (Display * dsp, Drawable win)
 {
 #define	COMPASSHH	25	/* compass half-height, pixels */
 	XCharStruct xcs;	/* char metrics */
@@ -8525,11 +8269,7 @@ Drawable win;
 
 /* draw the ecliptic */
 static void
-draw_ecliptic(np, dsp, win, gc)
-Now *np;
-Display *dsp;
-Window win;
-GC gc;
+draw_ecliptic(Now * np, Display * dsp, Window win, GC gc)
 {
 	XPoint ptcache[100];
         double elat0, elng0;    /* ecliptic lat and long at center of fov */
@@ -8722,11 +8462,7 @@ GC gc;
 
 /* draw the [pe]numbra, and throw in the anti-solar point too */
 static void
-draw_umbra(np, dsp, win, gc)
-Now *np;
-Display *dsp;
-Window win;
-GC gc;
+draw_umbra(Now * np, Display * dsp, Window win, GC gc)
 {
 	Obj *sop, *mop;
 	double altdec, azra;
@@ -8784,11 +8520,7 @@ GC gc;
 
 /* draw the equator */
 static void
-draw_equator(np, dsp, win, gc)
-Now *np;
-Display *dsp;
-Window win;
-GC gc;
+draw_equator(Now * np, Display * dsp, Window win, GC gc)
 {
 	XPoint ptcache[100];
 	double alt0, az0, ra0, dec0;
@@ -8898,11 +8630,7 @@ GC gc;
 
 /* draw the galactic plane and poles */
 static void
-draw_galactic(np, dsp, win, gc)
-Now *np;
-Display *dsp;
-Window win;
-GC gc;
+draw_galactic(Now * np, Display * dsp, Window win, GC gc)
 {
 	XPoint ptcache[100];
 	double e = epoch == EOD ? mjd : epoch;
@@ -9043,11 +8771,7 @@ GC gc;
 /* draw the Milky Way */
 /* Pertti Paakkonen, Nov. 24, 2003 */
 static void
-draw_milkyway(np, dsp, win, gc)
-Now *np;
-Display *dsp;
-Window win;
-GC gc;
+draw_milkyway(Now * np, Display * dsp, Window win, GC gc)
 {
 	/* rough presentation of the Milky Way edges */
 	static float mw1[257][2] = {
@@ -9295,10 +9019,7 @@ GC gc;
 
 /* draw the constellation lines */
 static void
-draw_cnsbounds(np, dsp, win)
-Now *np;
-Display *dsp;
-Window win;
+draw_cnsbounds(Now * np, Display * dsp, Window win)
 {
 #define	NCONSEGS    23	/* draw with this fraction of r (primes look best) */
 	double alt, az, ra, dec;
@@ -9427,12 +9148,7 @@ Window win;
  * return 1 if had to split, else 0.
  */
 static int
-split_line (dsp, win, gc, x1, y1, x2, y2)
-Display *dsp;
-Window win;
-GC gc;
-int x1, y1;
-int x2, y2;
+split_line (Display * dsp, Window win, GC gc, int x1, int y1, int x2, int y2)
 {
 	if (cyl_proj) {
 	    XSegment xs;
@@ -9454,12 +9170,7 @@ int x2, y2;
  * N.B. we assume np >= 2.
  */
 static int
-split_lines (dsp, win, gc, xp, np)
-Display *dsp;
-Window win;
-GC gc;
-XPoint xp[];
-int np;
+split_lines (Display * dsp, Window win, GC gc, XPoint xp[], int np)
 {
 	if (cyl_proj) {
 	    int ns = np-1;
@@ -9489,12 +9200,7 @@ int np;
  * N.B. unlike XPSDrawSegments we may modify sp[] IN PLACE
  */
 static int
-split_segs (dsp, win, gc, xsp, ns)
-Display *dsp;
-Window win;
-GC gc;
-XSegment xsp[];
-int ns;
+split_segs (Display * dsp, Window win, GC gc, XSegment xsp[], int ns)
 {
 	int nsplit = 0;
 
@@ -9525,9 +9231,7 @@ int ns;
  * if so, return how far to wrap in each direction, or 0 if none.
  */
 static void
-split_wrap (sp, xwp, ywp)
-XSegment *sp;
-int *xwp, *ywp;
+split_wrap (XSegment * sp, int * xwp, int * ywp)
 {
 	double scale = sv_h/sv_vfov;
 	int diff;
@@ -9545,10 +9249,7 @@ int *xwp, *ywp;
 
 /* draw the constellation figures and/or names */
 static void
-draw_cns(np, dsp, win)
-Now *np;
-Display *dsp;
-Window win;
+draw_cns(Now * np, Display * dsp, Window win)
 {
 #define	BBOX(x1,y1,x2,y2)   {				\
 	    if (want_conn || want_cona) {		\
@@ -9633,11 +9334,7 @@ Window win;
 
 /* draw the name of the given constellation centered in the bounding box */
 static void
-draw_cnsname (dsp, win, conid, minx, miny, maxx, maxy)
-Display *dsp;
-Window win;
-int conid;
-int minx, miny, maxx, maxy;
+draw_cnsname (Display * dsp, Window win, int conid, int minx, int miny, int maxx, int maxy)
 {
 	char *name = cns_name (conid);
 	XCharStruct all;
@@ -9663,15 +9360,12 @@ int minx, miny, maxx, maxy;
 /* draw a label for an object that is located at [x,y] with symbol diam d.
  * the label consists OBJF_* in flags.
  * label may contain greek names with superscripts.
+@param flags;	 mask of OBJF_{L,R,N,M,PERSLB}LABEL set 
+@param x, y;	 center of object we are labeling, pixels 
+@param d;		 diam of object we are labeling, pixels 
  */
 static void
-draw_label (win, gc, op, flags, x, y, d)
-Window win;
-GC gc;
-Obj *op;
-int flags;	/* mask of OBJF_{L,R,N,M,PERSLB}LABEL set */
-int x, y;	/* center of object we are labeling, pixels */
-int d;		/* diam of object we are labeling, pixels */
+draw_label (Window win, GC gc, Obj * op, int flags, int x, int y, int d)
 {
 	Display *dsp = XtDisplay (svda_w);
 	char *name = op->o_name;
@@ -9765,12 +9459,12 @@ int d;		/* diam of object we are labeling, pixels */
 /* see if the given name is of the form "Cns BayerN-Flams". If so, find the
  * number of chars in the Bayer (greek) part and the greek font code and ret 1.
  * else return 0.
+@param name[];	name 
+@param *glp;	 number of chars in the greek name part 
+@param *gcodep;	 code to use for drawing the greek character 
  */
 static int
-chk_greeklabel (name, glp, gcodep)
-char name[];	/* name */
-int *glp;	/* number of chars in the greek name part */
-char *gcodep;	/* code to use for drawing the greek character */
+chk_greeklabel (char name[], int * glp, char * gcodep)
 {
 	static char *greeks[] = {
 	    "Alpha", "Beta",    "Gamma",   "Delta", "Epsilon", "Zeta",
@@ -9821,10 +9515,7 @@ char *gcodep;	/* code to use for drawing the greek character */
 
 /* draw all visible eyepieces */
 static void
-draw_eyep (dsp, win, gc)
-Display *dsp;
-Window win;
-GC gc;
+draw_eyep (Display * dsp, Window win, GC gc)
 {
 	int cir = 360*64;/* 360 degrees in X */
 	EyePiece *eyep;
@@ -10026,9 +9717,7 @@ sv_mk_gcs()
  * keep a cache so we don't mess with it any more than necessary.
  */
 static void
-sv_set_dashed_cnsgc (dsp, dashed)
-Display *dsp;
-int dashed;
+sv_set_dashed_cnsgc (Display * dsp, int dashed)
 {
 	static int last_dashed = -1243;	/* anything bogus */
 	XGCValues xgcv;
@@ -10047,9 +9736,7 @@ int dashed;
  * N.B. we assume an image is indeed being displayed
  */
 static void
-sv_win2im (wx, wy, ix, iy)
-int wx, wy;
-double *ix, *iy;
+sv_win2im (int wx, int wy, double * ix, double * iy)
 {
 	if (flip_lr)
 	    wx = sv_w - 1 - wx;
@@ -10060,11 +9747,11 @@ double *ix, *iy;
 
 /* if a circular edge is showing clip, else just copy.
  * return 1 if any part MAY be visible, else 0.
+@param x1, y1, x2, y2;		 original segment 
+@param *cx1, *cy1, *cx2, *cy2;	 clipped segment 
  */ 
 static int
-segisvis (x1, y1, x2, y2, cx1, cy1, cx2, cy2)
-int x1, y1, x2, y2;		/* original segment */
-int *cx1, *cy1, *cx2, *cy2;	/* clipped segment */
+segisvis (int x1, int y1, int x2, int y2, int * cx1, int * cy1, int * cx2, int * cy2)
 {
 	int vis;
 
@@ -10091,9 +9778,7 @@ int *cx1, *cy1, *cx2, *cy2;	/* clipped segment */
 
 /* flip the given region, left/right else top/bottom */
 static void
-zm_flip0 (lr, zp)
-int lr;
-ZM_Undo *zp;
+zm_flip0 (int lr, ZM_Undo * zp)
 {
 	if (lr) {
 	    zp->x0 = sv_w - zp->x0;
@@ -10106,8 +9791,7 @@ ZM_Undo *zp;
 
 /* user has flipped image .. update zoom regions to match */
 static void
-zm_flip (lr)
-int lr;
+zm_flip (int lr)
 {
 	int i;
 
@@ -10251,10 +9935,7 @@ zm_draw()
  * client is secret code.. see various XtAdds
  */
 static void
-sv_fovsc_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_fovsc_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int code = (long int)client;
 
@@ -10296,10 +9977,7 @@ XtPointer call;
  * client is desired position, in degrees.
  */
 static void
-sv_altdecsc_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_altdecsc_cb (Widget w, XtPointer client, XtPointer call)
 {
 	si_off();
 	sv_altdec = degrad((long int)client);
@@ -10310,10 +9988,7 @@ XtPointer call;
 /* bring up telescope configure window */
 /* ARGSUSED */
 static void
-sv_tcp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_tcp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sc_manage();
 }
@@ -10321,10 +9996,7 @@ XtPointer call;
 /* bring up INDI operations panel window */
 /* ARGSUSED */
 static void
-sv_indi_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_indi_cb (Widget w, XtPointer client, XtPointer call)
 {
 	indi_manage();
 }
@@ -10332,10 +10004,7 @@ XtPointer call;
 /* callback when a Telescope history item is destroyed */
 /* ARGSUSED */
 static void
-sv_dtelpd_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_dtelpd_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPointer ud;
 
@@ -10347,10 +10016,7 @@ XtPointer call;
 /* callback to erase all telescope history */
 /* ARGSUSED */
 static void
-sv_etelpd_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_etelpd_cb (Widget w, XtPointer client, XtPointer call)
 {
 	sv_erasetelpd();
 }
@@ -10360,10 +10026,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-sv_telpd_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+sv_telpd_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj *op;
 
@@ -10375,8 +10038,7 @@ XtPointer call;
  * we add a new PB and store a copy of op in its userData.
  */
 static void
-sv_addtelpd (op)
-Obj *op;
+sv_addtelpd (Obj * op)
 {
 	char label[64];
 	XtPointer ud;
@@ -10449,9 +10111,7 @@ sv_erasetelpd ()
 /* called periodically to decide whether to reload field stars.
  */
 static void
-chkFS_to (client, id)
-XtPointer client;
-XtIntervalId *id;
+chkFS_to (XtPointer client, XtIntervalId * id)
 {
 	sv_loadfs(0);
 	fs_to = XtAppAddTimeOut (xe_app, FSTO, chkFS_to, 0);

--- a/GUI/xephem/solsysmenu.c
+++ b/GUI/xephem/solsysmenu.c
@@ -205,9 +205,7 @@ ss_manage ()
  */
 /* ARGSUSED */
 void
-ss_update (np, how_much)
-Now *np;
-int how_much;
+ss_update (Now * np, int how_much)
 {
 	if (!isUp(ssshell_w))
 	    return;
@@ -255,8 +253,7 @@ ss_ison()
 
 /* called to put up or remove the watch cursor.  */
 void
-ss_cursor (c)
-Cursor c;
+ss_cursor (Cursor c)
 {
 	Window win;
 
@@ -700,10 +697,7 @@ st_create_form()
  */
 /* ARGSUSED */
 static void
-ss_trail_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_trail_cb (Widget w, XtPointer client, XtPointer call)
 {
 	tr_setup ("xephem Solar System trails setup", "Solar System", &trstate,
 							    ss_newtrail, NULL);
@@ -713,10 +707,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int what = (long int) client;
 
@@ -762,10 +753,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_changed_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_changed_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScaleCallbackStruct *sp = (XmScaleCallbackStruct *) call;
 
@@ -782,10 +770,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do rest of the work */
 	XtPopdown (ssshell_w);
@@ -795,10 +780,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (ss_pm, dt_w);
 }
@@ -806,10 +788,7 @@ XtPointer call;
 /* callback from popping down the main view */
 /* ARGSUSED */
 static void
-ss_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (stform_w);
 
@@ -831,10 +810,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_print_cb (Widget w, XtPointer client, XtPointer call)
 {
         XPSAsk ("Solar System", ss_print);
 }
@@ -886,8 +862,7 @@ ss_print ()
 }
 
 static void
-ss_ps_annotate (np)
-Now *np;
+ss_ps_annotate (Now * np)
 {
 	char dir[128];
 	char buf[128];
@@ -963,11 +938,7 @@ Now *np;
  * SSScut(a,x) where a selects what and x is a factor.
  */
 static void
-ss_shortcuts (w, e, p, n)
-Widget w;
-XEvent *e;
-String *p;
-Cardinal *n;
+ss_shortcuts (Widget w, XEvent * e, String *p, Cardinal *n)
 {
 	int what, scale;
 	int add;
@@ -1025,10 +996,7 @@ Cardinal *n;
  */
 /* ARGSUSED */
 static void
-ss_anim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_anim_cb (Widget w, XtPointer client, XtPointer call)
 {
 	mm_movie (MOVIE_STEPSZ);
 }
@@ -1037,10 +1005,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This displays the solar system. The sun is always at the center. The left",
@@ -1057,10 +1022,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1069,10 +1031,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	Display *dsp = XtDisplay (w);
@@ -1129,10 +1088,7 @@ XtPointer call;
 
 /* ARGSUSED */
 static void
-st_parallax_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+st_parallax_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmScaleGetValue (w, &parallax);
 	ss_all ();
@@ -1141,10 +1097,7 @@ XtPointer call;
 /* called whenever the stereo scene is mapped. */
 /* ARGSUSED */
 static void
-st_map_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+st_map_cb (Widget w, XtPointer client, XtPointer call)
 {
 	st_track_size();
 }
@@ -1186,10 +1139,7 @@ st_track_size()
 /* callback from unmapping the stereo view */
 /* ARGSUSED */
 static void
-st_unmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+st_unmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	stereo = 0;
 	XmToggleButtonSetState(stereo_w, False, False);
@@ -1204,10 +1154,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-st_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+st_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	Display *dsp = XtDisplay (w);
@@ -1266,10 +1213,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_da_input_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_da_input_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Now *np = mm_get_now();
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1907,15 +1851,12 @@ st_refresh()
 /* draw all the comets and asteroids in the db.
  * if stview it's the stereo view so use st_pm and HLoc.stx, else ss_pm/sx.
  * add the coordinates in allp[] unless drawing the stereo view.
+@param scale;		 pixels per au 
+@param selt, celt;	 heliocentric lat of eye, rads 
+@param selg, celg;	 heliocentric lng of eye, rads 
  */
 static void
-ss_allobj (dsp, stview, scale, selt, celt, selg, celg, nx, ny)
-Display *dsp;
-int stview;
-double scale;		/* pixels per au */
-double selt, celt;	/* heliocentric lat of eye, rads */
-double selg, celg;	/* heliocentric lng of eye, rads */
-unsigned nx, ny;
+ss_allobj (Display * dsp, int stview, double scale, double selt, double celt, double selg, double celg, unsigned nx, unsigned ny)
 {
 #define	ASCHSZ		50
 	Now *np = mm_get_now();
@@ -2021,14 +1962,13 @@ unsigned nx, ny;
 
 /* compute location of HLoc in window of size [nx,ny].
  * N.B. others assume we only use hp->{x,y,z} and set lp->{sx,sy,sty}
+@param scale;		 mag factor 
+@param selt, celt;	 sin/cos heliocentric lat of eye, rads 
+@param selg, celg;	 sin/cos heliocentric lng of eye, rads 
+@param nx, ny;	 size of drawing area, in pixels 
  */
 static void
-ss_loc (hp, scale, selt, celt, selg, celg, nx, ny)
-HLoc *hp;
-double scale;		/* mag factor */
-double selt, celt;	/* sin/cos heliocentric lat of eye, rads */
-double selg, celg;	/* sin/cos heliocentric lng of eye, rads */
-unsigned nx, ny;	/* size of drawing area, in pixels */
+ss_loc (HLoc *hp, double scale, double selt, double celt, double selg, double celg, unsigned nx, unsigned ny)
 {
 	double x, y, z;	/* progressive transform values... */
 	double xp, yp, zp;
@@ -2081,10 +2021,7 @@ unsigned nx, ny;	/* size of drawing area, in pixels */
  */
 /* ARGSUSED */
 static int
-ss_newtrail (ts, statep, client)
-TrTS ts[];
-TrState *statep;
-XtPointer client;
+ss_newtrail (TrTS ts[], TrState * statep, XtPointer client)
 {
 	Now *np = mm_get_now();
 	int i;
@@ -2146,8 +2083,7 @@ XtPointer client;
  * new favorite at *np, and erase any other entries.
  */
 static void
-hloc_reset (np)
-Now *np;
+hloc_reset (Now * np)
 {
 	int i;
 
@@ -2182,8 +2118,7 @@ Now *np;
  *   return its new address or NULL and xe_msg() if no more memory.
  */
 static HLoc *
-hloc_grow (favi)
-int favi;
+hloc_grow (int favi)
 {
 	char *newmem;
 	int i, n;
@@ -2222,10 +2157,7 @@ int favi;
  * return 0 if ok else xe_msg() and -1 if trouble.
  */
 static int
-hloc_add (favi, np, lbl)
-int favi;
-Now *np;
-int lbl;
+hloc_add (int favi, Now * np, int lbl)
 {
 	Obj *op = favs[favi];
 	HLoc *hp;
@@ -2289,9 +2221,7 @@ ap_free()
  * return 0 if ok else -1.
  */
 static int
-ap_add (op, hp)
-Obj *op;
-HLoc *hp;
+ap_add (Obj * op, HLoc * hp)
 {
 	AllP *ap;
 
@@ -2322,10 +2252,7 @@ HLoc *hp;
  */
 /* ARGSUSED */
 static void
-ap_label_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ap_label_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj *op = pu.op;
 
@@ -2341,10 +2268,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ss_fav_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ss_fav_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj *op = pu.op;
 	if (op == db_basic(MOON))

--- a/GUI/xephem/srchmenu.c
+++ b/GUI/xephem/srchmenu.c
@@ -64,7 +64,7 @@ static char srchvname[] = "SolveValue";
 static char solvecategory[] = "Tools -- Solve";	/* Save category */
 static char xml_srchele[] = "XEphemSolver";
 
-static int (*srch_f)();		/* 0 or pointer to one of the search functions*/
+static int (*srch_f)(double, double, double *);		/* 0 or pointer to one of the search functions*/
 static int srch_tmscalled;	/* number of iterations so far */
 static double tmlimit;		/* search accuracy, hrs */
 static char config_suffix[] = ".svc";	/* file ext for solver config files */
@@ -110,10 +110,10 @@ srch_manage ()
  * first on or the last off.
  * N.B. we cooperate with a flag from the Enable pushbutton to prevent
  *   being able use the search function result as a term in the search funtion.
+@param whether;	 whether setting up for plotting or for not plotting 
  */
 void
-srch_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+srch_selection_mode (int whether)
 {
 	if (srch_self_selection_mode)
 	    return;
@@ -136,8 +136,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
  * too so it might not really be us that wants to use it.
  */
 void
-srch_selection (name)
-char *name;
+srch_selection (char * name)
 {
 	int ins;
 	char *qname;
@@ -167,9 +166,7 @@ char *name;
  * return 0 if caller can continue or -1 if it is time to stop.
  */
 int
-srch_eval(Mjd, tmincp)
-double Mjd;
-double *tmincp;
+srch_eval(double Mjd, double * tmincp)
 {
 	int s;
 
@@ -214,9 +211,7 @@ srch_ison()
  *   the srch function itself.
  */
 void
-srch_log (name, value)
-char *name;
-double value;
+srch_log (char * name, double value)
 {
 	if (any_ison())
 	    compiler_log (name, value);
@@ -224,8 +219,7 @@ double value;
 
 /* called to put up or remove the watch cursor.  */
 void
-srch_cursor (c)
-Cursor c;
+srch_cursor (Cursor c)
 {
 	Window win;
 
@@ -594,10 +588,10 @@ srching_now()
 
 /* go through all the buttons pickable for plotting and set whether they
  * should appear to look like buttons.
+@param whether;	whether setting up for plotting or for not plotting 
  */
 static void
-srch_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+srch_set_buttons (int whether)
 {
 	buttonAsButton(valu_w, whether);
 }
@@ -609,10 +603,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
  */
 /* ARGSUSED */
 static void
-srch_use_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_use_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (srch_selecting) {
 	    if (prog_isgood()) {
@@ -627,10 +618,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_newfunc_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_newfunc_cb (Widget w, XtPointer client, XtPointer call)
 {
 	f_showit (err_w, "New function not compiled");
 }
@@ -640,10 +628,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_loadfn_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_loadfn_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char msg[1024];
 	char *g, *f, *a;
@@ -695,10 +680,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_savefn_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_savefn_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char buf[1024], *txt;
 	char *goal;
@@ -751,10 +733,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_compile_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_compile_cb (Widget w, XtPointer client, XtPointer call)
 {
 	compile_func();
 }
@@ -763,10 +742,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 static char *help_msg[] = {
 "This menu controls the automatic searching facility. You define an arithmetic",
@@ -790,10 +766,7 @@ static char *help_msg[] = {
  */
 /* ARGSUSED */
 static void
-srch_clear_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_clear_cb (Widget w, XtPointer client, XtPointer call)
 {
 	char *txt = XmTextGetString (func_w);
 	XmTextReplace (func_w, 0, strlen(txt), "");
@@ -806,10 +779,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_fields_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_fields_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int whether = XmToggleButtonGetState(w);
 
@@ -823,10 +793,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (srchshell_w);
 }
@@ -834,10 +801,7 @@ XtPointer call;
 /* user typed Return in accuracy field. get his new value and use it */
 /* ARGSUSED */
 static void
-srch_acc_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_acc_cb (Widget w, XtPointer client, XtPointer call)
 {
 	get_tmlimit();
 }
@@ -848,10 +812,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_goal_cb(w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_goal_cb(Widget w, XtPointer client, XtPointer call)
 {
 	int (*sfp)()= (int (*)())client;
 
@@ -867,10 +828,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-srch_on_off_cb(w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+srch_on_off_cb(Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg =
 	    "You must first successfully compile a search Function and\n select a Goal algorithm before searching may be enabled.";
@@ -933,10 +891,7 @@ compile_func()
  * return -1 when finished.
  */
 static int
-srch_max(Mjd, v, tmincp)
-double Mjd;
-double v;
-double *tmincp;
+srch_max(double Mjd, double v, double * tmincp)
 {
 	static double v0, lastv0, j0, v1, lastv1, j1;
 	static double lastv;
@@ -978,10 +933,7 @@ double *tmincp;
  * return -1 when finished.
  */
 static int
-srch_min(Mjd, v, tmincp)
-double Mjd;
-double v;
-double *tmincp;
+srch_min(double Mjd, double v, double * tmincp)
 {
 	static double v0, lastv0, j0, v1, lastv1, j1;
 	static double lastv;
@@ -1022,10 +974,7 @@ double *tmincp;
  * uses globals srch_tmscalled and tmlimit.
  */
 static int
-srch_solve0(Mjd, v, tmincp)
-double Mjd;
-double v;
-double *tmincp;
+srch_solve0(double Mjd, double v, double * tmincp)
 {
 	static double x0, x_1;	/* x(n-1) and x(n) */
 	static double y_0, y_1;	/* y(n-1) and y(n) */
@@ -1058,10 +1007,7 @@ double *tmincp;
  *    direction by tminc first before starting to divide down.
  */
 static int
-srch_binary(Mjd, v, tmincp)
-double Mjd;
-double v;
-double *tmincp;
+srch_binary(double Mjd, double v, double * tmincp)
 {
 	static double lb, ub;		/* lower and upper bound */
 	static int initial_state;

--- a/GUI/xephem/time.c
+++ b/GUI/xephem/time.c
@@ -17,8 +17,7 @@ static double mjd0;
  * this establishes the base correspondence between the mjd and system clock.
  */
 void
-set_t0 (np)
-Now *np;
+set_t0 (Now * np)
 {
 	mjd0 = mjd;
 	c0 = time (NULL);
@@ -29,8 +28,7 @@ Now *np;
  *   many conflicting ways to do it otherwise.
  */
 void
-time_fromsys (np)
-Now *np;
+time_fromsys (Now* np)
 {
 	time_t t;
 
@@ -60,8 +58,7 @@ Now *np;
  * return 0 if it looks like it worked, else -1.
  */
 int
-tz_fromsys (np)
-Now *np;
+tz_fromsys (Now *np)
 {
 	struct tm *gtmp;
 	double m0;
@@ -103,12 +100,13 @@ Now *np;
 	    return (-1);
 }
 
+/*
+@param inc;	 hours to increment mjd 
+@param rev;	 set if want to go in reverse 
+@param rtcflag;	 relative since set mjd0 
+*/
 void
-inc_mjd (np, inc, rev, rtcflag)
-Now *np;
-double inc;	/* hours to increment mjd */
-int rev;	/* set if want to go in reverse */
-int rtcflag;	/* relative since set mjd0 */
+inc_mjd (Now * np, double inc, int rev, int rtcflag)
 {
 	if (rtcflag) {
 	    if (rev)

--- a/GUI/xephem/tips.c
+++ b/GUI/xephem/tips.c
@@ -56,9 +56,7 @@ static int tips_sorted;		/* flag set when tips array is sorted */
 
 /* connect the given string as the tip for the given widget */
 void
-wtip (w, tip)
-Widget w;
-char *tip;
+wtip (Widget w, char * tip)
 {
 	/* gadgets don't have windows and hence no events or even a XtDisplay */
 	if (XmIsGadget (w)) {
@@ -154,9 +152,7 @@ wtip_init ()
  * array as unsorted. it will be sorted before being used.
  */
 static void
-tip_new (w, s)
-Widget w;
-String s;
+tip_new (Widget w, String s)
 {
 	Tip *tp, *ltp;
 
@@ -189,8 +185,7 @@ String s;
 
 /* reclaim storage for tip info associated with w */
 static void
-tip_reclaim (w)
-Widget w;
+tip_reclaim (Widget w)
 {
 	Tip *tp;
 
@@ -210,11 +205,7 @@ Widget w;
 
 /* event handler -- c is 1 if want up, 0 for down */
 static void
-tip_eh (w, c, e, cont)
-Widget w;
-XtPointer c;
-XEvent *e;
-Boolean *cont;
+tip_eh (Widget w, XtPointer c, XEvent * e, Boolean * cont)
 {
 	Tip *tp;
 	int wantup;
@@ -242,8 +233,7 @@ Boolean *cont;
 
 /* start a timer which, if it springs, will pop up the given tip */
 static void
-tip_startup (tp)
-Tip *tp;
+tip_startup (Tip * tp)
 {
 	XtAppContext ac = XtWidgetToApplicationContext (tp->w);
 
@@ -254,9 +244,7 @@ Tip *tp;
 /* timer expired so pop up tip for widget in client unless went DOWN again */
 /* ARGSUSED */
 static void
-timer_cb (client, id)
-XtPointer client;
-XtIntervalId *id;
+timer_cb (XtPointer client, XtIntervalId * id)
 {
 	Widget w = (Widget)client;
 	Tip *tp = tip_find (w);
@@ -273,8 +261,7 @@ XtIntervalId *id;
 
 /* pop up the given tip */
 static void
-tip_up (tp)
-Tip *tp;
+tip_up (Tip * tp)
 {
 	Display *dsp = XtDisplay (tp->w);
 	Window win = XtWindow (tp->w);
@@ -322,8 +309,7 @@ Tip *tp;
 
 /* pop down the tip window */
 static void
-tip_down(tp)
-Tip *tp;
+tip_down(Tip * tp)
 {
 	XUnmapWindow (XtDisplay(tp->w), the_w);
 }
@@ -331,10 +317,7 @@ Tip *tp;
 /* w is being destroyed so reclaim its tip info */
 /* ARGSUSED */
 static void
-tip_destroy_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+tip_destroy_cb (Widget w, XtPointer client, XtPointer call)
 {
 	tip_reclaim (w);
 }
@@ -343,8 +326,7 @@ XtPointer call;
  * use a binary search. sort the array first if necessary.
  */
 static Tip *
-tip_find (w)
-Widget w;
+tip_find (Widget w)
 {
 	long wl = (long)w;
 	long s;

--- a/GUI/xephem/trailmenu.c
+++ b/GUI/xephem/trailmenu.c
@@ -228,9 +228,7 @@ TrTS *ltp, TrState *sp, int lx, int ly, int x, int y)
 /* set a trail state resource
  */
 void
-tr_setres (name, state)
-char *name;
-TrState *state;
+tr_setres (char * name, TrState * state)
 {
 	char val[50];
 
@@ -244,9 +242,7 @@ TrState *state;
 /* get a trail state from a resource
  */
 void
-tr_getres (name, state)
-char *name;
-TrState *state;
+tr_getres (char * name, TrState * state)
 {
 	char *val;
 	int l, i, f, r, o, s, n, b;
@@ -276,12 +272,7 @@ TrState *state;
  * to free this whenever the window is destroyed.
  */
 static Widget
-create_form (title, hdr, init, cb, client)
-char *title;
-char *hdr;
-TrState *init;
-TrCB cb;
-XtPointer client;
+create_form (char * title, char * hdr, TrState * init, TrCB cb, XtPointer client)
 {
 	TrContext *tcp;
 	Widget ok_w, apply_w, close_w, help_w;
@@ -655,13 +646,7 @@ XtPointer client;
  * would use frame's new title child but don't want to lock into 1.2 (yet)
  */
 static void
-make_rb (rc_w, title, name, op, nop, savew)
-Widget rc_w;
-char *title;
-char *name;
-RCOption *op;
-int nop;
-Widget savew[];
+make_rb (Widget rc_w, char * title, char * name, RCOption * op, int nop, Widget savew[])
 {
 	Widget l_w, rb_w, w;
 	XmString str;
@@ -701,10 +686,7 @@ Widget savew[];
  */
 /* ARGSUSED */
 static void
-customint_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+customint_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtSetSensitive ((Widget)client, XmToggleButtonGetState(w));
 }
@@ -716,10 +698,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	TrContext *tcp;
 
@@ -737,10 +716,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-apply_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+apply_cb (Widget w, XtPointer client, XtPointer call)
 {
 	TrContext *tcp;
 
@@ -755,8 +731,7 @@ XtPointer call;
  * return 0 if ok, else -1.
  */
 static int
-do_trails (tcp)
-TrContext *tcp;
+do_trails (TrContext * tcp)
 {
 	Now *np = mm_get_now();
 	TrState state;
@@ -911,10 +886,7 @@ TrContext *tcp;
 
 /* advance t forward or backward based on state */
 static void
-tStep (tp, statep, sign)
-double *tp;
-TrState *statep;
-int sign;
+tStep (double * tp, TrState * statep, int sign)
 {
 	int m, y;
 	double d;
@@ -958,9 +930,7 @@ int sign;
  * return 0 if ok, else xe_msg() wny not and return -1.
  */
 static int
-get_options(tcp, statep)
-TrContext *tcp;
-TrState *statep;
+get_options(TrContext * tcp, TrState * statep)
 {
 	int i, j;
 
@@ -1076,10 +1046,7 @@ TrState *statep;
 /* called when unmapped */
 /* ARGSUSED */
 static void
-popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* N.B. don't free the userData here -- wait for destroy.
 	 * turns out unmap callbacks run before ok_cb!
@@ -1090,10 +1057,7 @@ XtPointer call;
 /* called when destroyed, client is TrContext to be free'd */
 /* ARGSUSED */
 static void
-destroy_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+destroy_cb (Widget w, XtPointer client, XtPointer call)
 {
 	free ((char *)client);
 }
@@ -1103,10 +1067,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	TrContext *tcp;
 
@@ -1119,10 +1080,7 @@ XtPointer call;
 /* called when the Help button is hit */
 /* ARGSUSED */
 static void
-help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+help_cb (Widget w, XtPointer client, XtPointer call)
 {
         hlp_dialog ("Trails", NULL, 0);
 }
@@ -1131,16 +1089,7 @@ XtPointer call;
  * direction, size and content depend on tp, sp and the line endpoints.
  */
 static void
-draw_stamp (dsp, win, gc, tp, sp, mark, ticklen, lx, ly, x, y)
-Display *dsp;
-Drawable win;
-GC gc;
-TrTS *tp;
-TrState *sp;
-int mark;
-int ticklen;
-int lx, ly;
-int x, y;
+draw_stamp (Display * dsp, Drawable win, GC gc, TrTS * tp, TrState * sp, int mark, int ticklen, int lx, int ly, int x, int y)
 {
 	char buf[64], *bp;
 	double mag = 1.0;

--- a/GUI/xephem/ucac.c
+++ b/GUI/xephem/ucac.c
@@ -128,7 +128,7 @@ int nopp,       /* if opp: initial number of ObjF already in *opp */
 char msg[] 	/* status or error message if msg[0] != '\0' on return */
 )
 {
-	int (*doucac)() = 0;		/* function to process */
+	int (*doucac)(ObjFArray *oap, int rz, int dz) = 0;		/* function to process */
 	int d0z, drovz;			/* dec center and radius, in 0-zones */
 	ObjFArray oa;			/* malloc accumulator */
 	int dz;				/* scanning dec zone number */

--- a/GUI/xephem/uranusmenu.c
+++ b/GUI/xephem/uranusmenu.c
@@ -169,9 +169,7 @@ um_manage ()
  * don't bother if it doesn't exist or is unmanaged now or no one is logging.
  */
 void
-um_update (np, how_much)
-Now *np;
-int how_much;
+um_update (Now * np, int how_much)
 {
 	static char fmt[] = "%7.3f";
 	Obj *eop = db_basic (SUN);
@@ -240,8 +238,7 @@ um_newres()
  */
 /* ARGSUSED */
 void
-um_newdb (appended)
-int appended;
+um_newdb (int appended)
 {
 	if (skybkg)
 	    um_update (mm_get_now(), 1);
@@ -256,10 +253,10 @@ um_ison()
 /* called by other menus as they want to hear from our buttons or not.
  * the "on"s and "off"s stack - only really redo the buttons if it's the
  * first on or the last off.
+@param whether;	 whether setting up for plotting or for not plotting 
  */
 void
-um_selection_mode (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+um_selection_mode (int whether)
 {
 	if (whether)
 	    um_selecting++;
@@ -274,8 +271,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 
 /* called to put up or remove the watch cursor.  */
 void
-um_cursor (c)
-Cursor c;
+um_cursor (Cursor c)
 {
 	Window win;
 
@@ -890,10 +886,10 @@ um_create_tvform_w()
 
 /* go through all the buttons pickable for plotting and set whether they
  * should appear to look like buttons or just flat labels.
+@param whether;	 whether setting up for plotting or for not plotting 
  */
 static void
-um_set_buttons (whether)
-int whether;	/* whether setting up for plotting or for not plotting */
+um_set_buttons (int whether)
 {
 	int i, j;
 
@@ -906,10 +902,7 @@ int whether;	/* whether setting up for plotting or for not plotting */
 /* callback when the Close button is activated on the stats menu */
 /* ARGSUSED */
 static void
-um_sstats_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_sstats_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (usform_w);
 }
@@ -917,10 +910,7 @@ XtPointer call;
 /* callback when the More Info button is activated */
 /* ARGSUSED */
 static void
-um_sstats_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_sstats_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtManageChild (usform_w);
 	um_set_buttons(um_selecting);
@@ -930,10 +920,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_cpdmapping_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_cpdmapping_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtSetSensitive (tel_w, telIsOn());
 }
@@ -944,10 +931,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_option_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_option_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (client) {
 	    int *flagp = (int *)client;
@@ -970,10 +954,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_scale_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_scale_cb (Widget w, XtPointer client, XtPointer call)
 {
 	um_update (mm_get_now(), 1);
 }
@@ -982,10 +963,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (um_selecting) {
 	    char *name;
@@ -998,10 +976,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ut_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ut_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1056,10 +1031,7 @@ XtPointer call;
 /* called whenever the topview scene is mapped. */
 /* ARGSUSED */
 static void
-ut_map_cb (wid, client, call)
-Widget wid;
-XtPointer client;
-XtPointer call;
+ut_map_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ut_track_size();
 }
@@ -1111,10 +1083,7 @@ ut_track_size()
 /* callback when topview dialog is unmapped */
 /* ARGSUSED */
 static void
-ut_unmap_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+ut_unmap_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmToggleButtonSetState (topview_w, False, True);
 }
@@ -1122,10 +1091,7 @@ XtPointer call;
 /* callback when main shell is popped down */
 /* ARGSUSED */
 static void
-um_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtUnmanageChild (usform_w);
 	XtUnmanageChild (utform_w);
@@ -1152,10 +1118,7 @@ XtPointer call;
 /* callback from the main Close button */
 /* ARGSUSED */
 static void
-um_close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* let popdown do all the work */
 	XtPopdown (ushell_w);
@@ -1164,10 +1127,7 @@ XtPointer call;
 /* callback to add this scene to the movie loop */
 /* ARGSUSED */
 static void
-um_mloop_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_mloop_cb (Widget w, XtPointer client, XtPointer call)
 {
 	ml_add (um_pm, dt_w);
 }
@@ -1176,10 +1136,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_anim_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_anim_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* best effect if turn off worrying about the sky background */
 	skybkg = 0;
@@ -1192,10 +1149,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static int last_nx, last_ny;
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
@@ -1253,10 +1207,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_da_input_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_da_input_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 	ScreenObj *sop;
@@ -1320,8 +1271,7 @@ um_create_popup()
 
 /* put up a popup at ev with info about sop */
 static void
-um_fill_popup (sop)
-ScreenObj *sop;
+um_fill_popup (ScreenObj * sop)
 {
 	char *name;
 	double ra, dec, mag;
@@ -1351,10 +1301,7 @@ ScreenObj *sop;
  */
 /* ARGSUSED */
 static void
-um_help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_help_cb (Widget w, XtPointer client, XtPointer call)
 {
 	static char *msg[] = {
 "This is a simple schematic depiction of Uranus and its moons.",
@@ -1368,10 +1315,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_helpon_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_helpon_cb (Widget w, XtPointer client, XtPointer call)
 {
 	hlp_dialog ((char *)client, NULL, 0);
 }
@@ -1380,10 +1324,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-um_goto_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_goto_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Obj *op = db_basic (URANUS);
 	telGoto (op);
@@ -1392,10 +1333,7 @@ XtPointer call;
 /* add one entry to the given global screenobj array.
  */
 static void
-add_screenobj (soidx, op, x, y)
-SOIdx soidx;
-Obj *op;
-int x, y;
+add_screenobj (SOIdx soidx, Obj * op, int x, int y)
 {
 	char *mem = (char *) screenobj[soidx];
 	int nmem = nscreenobj[soidx];
@@ -1422,8 +1360,7 @@ int x, y;
 
 /* reclaim any existing screenobj entries from the given collection */
 static void
-reset_screenobj(soidx)
-SOIdx soidx;
+reset_screenobj(SOIdx soidx)
 {
 	if (screenobj[soidx]) {
 	    free ((char *)screenobj[soidx]);
@@ -1436,9 +1373,7 @@ SOIdx soidx;
  * if found return the ScreenObj *, else NULL.
  */
 static ScreenObj *
-close_screenobj (soidx, x, y)
-SOIdx soidx;
-int x, y;
+close_screenobj (SOIdx soidx, int x, int y)
 {
 	ScreenObj *scop = screenobj[soidx];
 	ScreenObj *minsop = NULL;
@@ -1464,10 +1399,7 @@ int x, y;
  */
 /* ARGSUSED */
 static void
-um_print_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+um_print_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XPSAsk ("Uranus", um_print);
 }
@@ -1519,8 +1451,7 @@ um_print ()
 }
 
 static void
-um_ps_annotate (np)
-Now *np;
+um_ps_annotate (Now * np)
 {
 	int ctrx = (int)(8.5*72/2);
 	Obj *eop = db_basic (SUN);
@@ -1737,11 +1668,7 @@ Now *np;
  *     +md[].z: in front, u radii
  */
 static void
-um_draw_map (w, uop, usize, md)
-Obj *uop;
-Widget w;
-double usize;
-MoonData md[U_NMOONS];
+um_draw_map (Widget w, Obj * uop, double usize, MoonData md[U_NMOONS])
 {
 	Display *dsp = XtDisplay(w);
 	Window win;
@@ -2023,14 +1950,7 @@ make_gcs ()
  * with is in a bounding box tw x th.
  */
 static void
-u_calibline (dsp, win, gc, xc, yc, tag, tw, th, l)
-Display *dsp;
-Drawable win;
-GC gc;
-int xc, yc;
-char *tag;
-int tw, th;
-int l;
+u_calibline (Display * dsp, Drawable win, GC gc, int xc, int yc, char * tag, int tw, int th, int l)
 {
 	int lx = xc - l/2;
 	int rx = lx + l;
@@ -2053,16 +1973,16 @@ int l;
  * save objects and screen locs in the global screenobj array for picking.
  * this is used to draw the backgrounds for the planet closeups.
  * Based on work by: Dan Bruton <WDB3926@acs.tamu.edu>
+@param win;		 window to draw on 
+@param w, h;		 window size 
+@param fmag;		 faintest magnitude to display 
+@param ra0, dec0;	 center of patch, rads 
+@param scale;		 rads per pixel 
+@param rad;		 maximum radius to draw away from ra0/dec0, rads 
+@param fliptb, fliplr;	 flip direction; default is S up E right 
  */
 static void
-sky_background (win, w, h, fmag, ra0,dec0,scale,rad,fliptb,fliplr)
-Drawable win;		/* window to draw on */
-unsigned w, h;		/* window size */
-int fmag;		/* faintest magnitude to display */
-double ra0, dec0;	/* center of patch, rads */
-double scale;		/* rads per pixel */
-double rad;		/* maximum radius to draw away from ra0/dec0, rads */
-int fliptb, fliplr;	/* flip direction; default is S up E right */
+sky_background (Drawable win, unsigned w, unsigned h, int fmag, double ra0,double dec0,double scale,double rad,int fliptb,int fliplr)
 {
 	static int before;
 	double cdec0 = cos(dec0);
@@ -2128,8 +2048,7 @@ int fliptb, fliplr;	/* flip direction; default is S up E right */
  * already close enough.
  */
 static void
-um_loadfs (ra, dec)
-double ra, dec;
+um_loadfs (double ra, double dec)
 {
 	Now *np = mm_get_now();
 

--- a/GUI/xephem/usno.c
+++ b/GUI/xephem/usno.c
@@ -47,10 +47,7 @@ static int nogsc;		/* set to 1 to exclude GSC stars */
  * return 0 if looks ok, else -1 and reason in msg[].
  */
 int
-USNOSetup (cdp, wantgsc, msg)
-char *cdp;
-int wantgsc;
-char msg[];
+USNOSetup (char * cdp, int wantgsc, char msg[])
 {
 	char tstname[1024];
 	FILE *fp = NULL;
@@ -90,16 +87,16 @@ char msg[];
  * we return new total number of stars or -1 if real trouble.
  * *opp is only changed if we added any.
  * msg might contain a message regardless of the return value.
+param r0;	 center RA, rads 
+param d0;	 center Dec, rads
+param fov;	 field of view, rads
+param fmag;	 faintest mag 
+param **opp;	 opp will be a malloced array of the ObjF in region 
+param nopp;        if opp: initial number of ObjF already in *opp 
+param msg[];	 filled with error message if return -1 
  */
 int
-USNOFetch (r0, d0, fov, fmag, opp, nopp, msg)
-double r0;	/* center RA, rads */
-double d0;	/* center Dec, rads */
-double fov;	/* field of view, rads */
-double fmag;	/* faintest mag */
-ObjF **opp;	/* *opp will be a malloced array of the ObjF in region */
-int nopp;       /* if opp: initial number of ObjF already in *opp */
-char msg[];	/* filled with error message if return -1 */
+USNOFetch (double r0, double d0, double fov, double fmag, ObjF **opp, int nopp, char msg[])
 {
 	double fr[2], lr[2];	/* first and last ra in each region, up to 2 */
 	double fd[2], ld[2];	/* first and last dec in each region, up to 2 */

--- a/GUI/xephem/versionmenu.c
+++ b/GUI/xephem/versionmenu.c
@@ -148,8 +148,7 @@ version()
 
 /* called to put up or remove the watch cursor.  */
 void
-v_cursor (c)
-Cursor c;
+v_cursor (Cursor c)
 {
 	Window win;
 
@@ -257,8 +256,7 @@ v_create_vshell()
 }
 
 static void
-fill_msg (w)
-Widget w;
+fill_msg (Widget w)
 {
 	char m[100*NMSGR], *mp = m;
 	int i;
@@ -294,10 +292,7 @@ Widget w;
  */
 /* ARGSUSED */
 static void
-v_popdown_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+v_popdown_cb (Widget w, XtPointer client, XtPointer call)
 {
 	if (v_timer_id) {
 	    XtRemoveTimeOut (v_timer_id);
@@ -308,10 +303,7 @@ XtPointer call;
 /* ok */
 /* ARGSUSED */
 static void
-v_ok_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+v_ok_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XtPopdown (vshell_w);
 }
@@ -322,10 +314,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-v_da_exp_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+v_da_exp_cb (Widget w, XtPointer client, XtPointer call)
 {
 	XmDrawingAreaCallbackStruct *c = (XmDrawingAreaCallbackStruct *)call;
 
@@ -410,9 +399,7 @@ v_draw()
  */
 /* ARGSUSED */
 static void
-v_timer_cb (client, id)
-XtPointer client;
-XtIntervalId *id;
+v_timer_cb (XtPointer client, XtIntervalId * id)
 {
 	Display *dsp = XtDisplay(vda_w);
 	Window win = XtWindow(vda_w);
@@ -478,16 +465,13 @@ XtIntervalId *id;
 }
 
 /* draw the comet
+@param ang;	 desired angle ccw from +x, in rads 
+@param rad;	 in pixels from center 
+@param tlen;	 length of tail, in pixels 
+@param w, h;	 window width and height 
  */
 static void
-drawComet (dsp, win, gc, ang, rad, tlen, w, h)
-Display *dsp;
-Window win;
-GC gc;
-double ang;	/* desired angle ccw from +x, in rads */
-int rad;	/* in pixels from center */
-int tlen;	/* length of tail, in pixels */
-int w, h;	/* window width and height */
+drawComet (Display * dsp, Window win, GC gc, double ang, int rad, int tlen, int w, int h)
 {
 	double ca, sa;
 	int sx, sy;
@@ -512,11 +496,7 @@ int w, h;	/* window width and height */
 /* draw the planet.
  */
 static void
-drawPlanet (dsp, win, gc, sx, sy, w, h)
-Display *dsp;
-Window win;
-GC gc;
-int sx, sy, w, h;
+drawPlanet (Display * dsp, Window win, GC gc, int sx, int sy, int w, int h)
 {
 	XFillArc (dsp, win, gc, sx, sy, w, h, 0, 360*64);
 }

--- a/GUI/xephem/webdbmenu.c
+++ b/GUI/xephem/webdbmenu.c
@@ -71,8 +71,7 @@ wdb_manage()
 
 /* called to put up or remove the watch cursor.  */
 void
-wdb_cursor (c)
-Cursor c;
+wdb_cursor (Cursor c)
 {
 	Window win;
 
@@ -242,10 +241,7 @@ wdb_create()
 /* called from Close */
 /* ARGSUSED */
 static void
-close_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+close_cb (Widget w, XtPointer client, XtPointer call)
 {
 	/* outta here */
 	XtPopdown (wdbshell_w);
@@ -256,10 +252,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-geturl_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+geturl_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Widget tf_w = (Widget)client;
 	char *url = XmTextFieldGetString(tf_w);
@@ -275,10 +268,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-getast_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+getast_cb (Widget w, XtPointer client, XtPointer call)
 {
 	AstInfo *ap = (AstInfo *)client;
 	char cmd[1024];
@@ -316,9 +306,7 @@ XtPointer call;
  */
 /* ARGSUSED */
 static void
-ast_tcb (client, ip)
-XtPointer client;
-XtIntervalId *ip;
+ast_tcb (XtPointer client, XtIntervalId * ip)
 {
 	AstInfo *ap = (AstInfo *)client;
 	struct stat st;
@@ -351,10 +339,7 @@ XtIntervalId *ip;
  * client is AstInfo *.
  */
 static void
-ast_icb (client, fdp, idp)
-XtPointer client;
-int *fdp;
-XtInputId *idp;
+ast_icb (XtPointer client, int * fdp, XtInputId * idp)
 {
 	AstInfo *ap = (AstInfo *)client;
 	int fd = *fdp;
@@ -385,10 +370,7 @@ XtInputId *idp;
 /* called from Ok */
 /* ARGSUSED */
 static void
-help_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+help_cb (Widget w, XtPointer client, XtPointer call)
 {
         static char *msg[] = {"Download database files from the Web."};
 
@@ -401,8 +383,7 @@ XtPointer call;
  * collect what we find and save in basename(url).edb
  */
 static void
-getURL (url)
-char *url;
+getURL (char * url)
 {
 	static char http[] = "http://";
 	static char https[] = "https://";

--- a/GUI/xephem/xe2.c
+++ b/GUI/xephem/xe2.c
@@ -182,9 +182,7 @@ ObjF **opp, char *msg)
  * else NULL with a reason in msg[].
  */
 static FILE *
-xe2open (file, msg)
-char *file;
-char msg[];
+xe2open (char * file, char msg[])
 {
 	FILE *fp = fopenh (file, "rb");
 	char header[32];
@@ -209,10 +207,7 @@ char msg[];
 
 /* crack open pkt and fill in op */
 static void
-unpackObj (pkt, np, op)
-PKT pkt;
-Now *np;
-Obj *op;
+unpackObj (PKT pkt, Now * np, Obj * op)
 {
 #define	MASRAD(mas)	degrad((mas)/(3600.*1000.))
 	double ra;
@@ -246,9 +241,7 @@ Obj *op;
  * return 0 if ok else return -1
  */
 static int
-addOneObjF (ap, fop)
-ObjFArray *ap;
-ObjF *fop;
+addOneObjF (ObjFArray * ap, ObjF * fop)
 {
 	ObjF *newf;
 
@@ -272,16 +265,7 @@ ObjF *fop;
 /* unpack the raw PKT into its basic parts.
  */
 static void
-unpack (pkt, ra, dec, pma, pmd, mag, name, spect, type)
-PKT pkt;
-double *ra;
-double *dec;
-double *pma;
-double *pmd;
-double *mag;
-char name[MAXNM];
-char *spect;
-int *type;
+unpack (PKT pkt, double * ra, double * dec, double * pma, double * pmd, double * mag, char name[MAXNM], char * spect, int *type)
 {
 	UL t;
 

--- a/GUI/xephem/xephem.c
+++ b/GUI/xephem/xephem.c
@@ -61,7 +61,7 @@ typedef struct {
     char *acc;		/* button accelerator, if any */
     char *acctext;	/* button accelerator text, if any */
     char mne;		/* button mnemonic */
-    void (*cb)();	/* button callback, or NULL if none */
+    void (*cb)(Widget w, XtPointer client, XtPointer call);	/* button callback, or NULL if none */
     XtPointer client;	/* button callback client data */
 } ButtonInfo;
 typedef struct {
@@ -133,9 +133,7 @@ static XrmOptionDescRec options[] = {
 };
 
 int
-main(argc, argv)
-int argc;
-char *argv[];
+main(int argc, char * argv[])
 {
 	Arg args[10];
 	int n;
@@ -222,8 +220,7 @@ char *argv[];
 
 /* called to put up or remove the watch cursor.  */
 void
-main_cursor (c)
-Cursor c;
+main_cursor (Cursor c)
 {
 	Window win;
 
@@ -403,9 +400,7 @@ addOurDBs()
 
 /* ARGSUSED */
 static void
-chk_args (argc, argv)
-int argc;
-char *argv[];
+chk_args (int argc, char *argv[])
 {
 
 	if (getXRes ("log", NULL)) {
@@ -700,9 +695,7 @@ make_main_window ()
  * N.B. watch for special bip->name.
  */
 static Widget
-make_pulldown (mb_w, pdmp)
-Widget mb_w;
-PullDownMenu *pdmp;
+make_pulldown (Widget mb_w, PullDownMenu * pdmp)
 {
 	Widget pulldown_w;
 	Widget button;
@@ -890,10 +883,7 @@ initialUps()
  */
 /* ARGSUSED */
 static void
-m_activate_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+m_activate_cb (Widget w, XtPointer client, XtPointer call)
 {
 	int code = (long int)client;
 

--- a/GUI/xephem/xmisc.c
+++ b/GUI/xephem/xmisc.c
@@ -88,10 +88,7 @@ static int look_like_inited;
  * shouldn't use this if you have several things to set for the same widget.
  */
 void
-set_something (w, resource, value)
-Widget w;
-char *resource;
-XtArgVal value;
+set_something (Widget w, char * resource, XtArgVal value)
 {
 	Arg a[1];
 
@@ -108,10 +105,7 @@ XtArgVal value;
  * shouldn't use this if you have several things to get for the same widget.
  */
 void
-get_something (w, resource, value)
-Widget w;
-char *resource;
-XtArgVal value;
+get_something (Widget w, char * resource, XtArgVal value)
 {
 	Arg a[1];
 
@@ -130,10 +124,7 @@ XtArgVal value;
  *   XtFree (*txtp).
  */
 void
-get_xmstring (w, resource, txtp)
-Widget w;
-char *resource;
-char **txtp;
+get_xmstring (Widget w, char * resource, char **txtp)
 {
 	static char me[] = "get_xmstring()";
 	static char hah[] = "??";
@@ -157,10 +148,7 @@ char **txtp;
 }
 
 void
-set_xmstring (w, resource, txt)
-Widget w;
-char *resource;
-char *txt;
+set_xmstring (Widget w, char * resource, char * txt)
 {
 	XmString str;
 
@@ -176,8 +164,7 @@ char *txt;
 
 /* return 1 if w is on screen else 0 */
 int
-isUp (w)
-Widget w;
+isUp (Widget w)
 {
 	XWindowAttributes wa;
 	Display *dsp;
@@ -196,10 +183,7 @@ Widget w;
  */
 /* ARGSUSED */
 void
-prompt_map_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+prompt_map_cb (Widget w, XtPointer client, XtPointer call)
 {
 	Window root, child;
 	int rx, ry, wx, wy;	/* rx/y: cursor loc on root window */
@@ -240,10 +224,7 @@ XtPointer call;
  * return 0 if the color was found, -1 if White had to be used.
  */
 int
-get_color_resource (w, cname, p)
-Widget w;
-char *cname;
-Pixel *p;
+get_color_resource (Widget w, char * cname, Pixel * p)
 {
 	Display *dsp = XtDisplay(w);
 	Colormap cm;
@@ -274,9 +255,7 @@ Pixel *p;
 /* get the XFontStruct we want to use when drawing text for the display views.
  */
 void
-get_views_font (dsp, fspp)
-Display *dsp;
-XFontStruct **fspp;
+get_views_font (Display * dsp, XFontStruct ** fspp)
 {
 	if (!viewsfsp)
 	    viewsfsp = getXResFont ("viewsFont");
@@ -288,9 +267,7 @@ XFontStruct **fspp;
  * this also means setting all the GCs for objects.
  */
 void
-set_views_font (dsp, fsp)
-Display *dsp;
-XFontStruct *fsp;
+set_views_font (Display * dsp, XFontStruct * fsp)
 {
 	Font fid;
 	int i;
@@ -317,9 +294,7 @@ XFontStruct *fsp;
 /* get the XFontStruct we want to use when drawing text while tracking cursor.
  */
 void
-get_tracking_font (dsp, fspp)
-Display *dsp;
-XFontStruct **fspp;
+get_tracking_font (Display * dsp, XFontStruct **fspp)
 {
 	if (!trackingfsp)
 	    trackingfsp = getXResFont ("cursorTrackingFont");
@@ -330,9 +305,7 @@ XFontStruct **fspp;
 /* set the XFontStruct we want to use when drawing text while tracking cursor.
  */
 void
-set_tracking_font (dsp, fsp)
-Display *dsp;
-XFontStruct *fsp;
+set_tracking_font (Display * dsp, XFontStruct *fsp)
 {
 	/* TODO: free old? */
 	trackingfsp = fsp;
@@ -414,10 +387,7 @@ make_objgcs()
  * Use the colors defined for objects in the X resources, else White.
  */
 void
-obj_pickgc(op, w, gcp)
-Obj *op;
-Widget w;
-GC *gcp;
+obj_pickgc(Obj * op, Widget w, GC * gcp)
 {
 	/* insure GCs are ready */
 	if (!other_gc)
@@ -482,9 +452,7 @@ GC *gcp;
  * XFontStruct in its XmFontList.
  */
 void
-get_xmlabel_font (w, f)
-Widget w;
-XFontStruct **f;
+get_xmlabel_font (Widget w, XFontStruct **f)
 {
 	static char me[] = "get_xmlable_font";
 	XmFontList fl;
@@ -505,8 +473,7 @@ XFontStruct **f;
 
 /* get the font named by the given X resource, else fixed, else bust */
 XFontStruct *
-getXResFont (rn)
-char *rn;
+getXResFont (char * rn)
 {
 	static char fixed[] = "fixed";
 	char *fn = getXRes (rn, NULL);
@@ -580,10 +547,7 @@ loadGreek (Display *dsp, Drawable win, GC *greekgcp, XFontStruct **greekfspp)
  * N.B. don't change the pixels -- they are shared with other users.
  */
 int
-gray_ramp (dsp, cm, pixp)
-Display *dsp;
-Colormap cm;
-Pixel **pixp;
+gray_ramp (Display * dsp, Colormap cm, Pixel ** pixp)
 {
 	static Pixel gramp[MAXGRAY];
 	static int ngray;
@@ -855,9 +819,7 @@ char why[])
  * N.B. see setXRes for how newlines are handled in the Xrm.
  */
 char *
-getXRes (name, def)
-char *name;
-char *def;
+getXRes (char * name, char * def)
 {
 	static char notfound[] = "_Not_Found_";
 	char *res = NULL;
@@ -885,8 +847,7 @@ char *def;
  *   behavior as writing to and reading back one res to an app-defaults file.
  */
 void
-setXRes (name, val)
-char *name, *val;
+setXRes (char * name, char * val)
 {
 	XrmDatabase db = XrmGetDatabase (XtDisplay(toplevel_w));
 	char buf[1024];
@@ -899,8 +860,7 @@ char *name, *val;
  * nnew is how many colors we expect to add.
  */
 Colormap
-createCM(nnew)
-int nnew;
+createCM(int nnew)
 {
 #define	NPRECM	50  /* try to preload new cm with NPRECM colors from def cm */
 	Display *dsp = XtDisplay (toplevel_w);
@@ -932,9 +892,7 @@ int nnew;
  * colors, return a new colormap or cm again.
  */
 Colormap
-checkCM(cm, nwant)
-Colormap cm;
-int nwant;
+checkCM(Colormap cm, int nwant)
 {
 	Display *dsp = XtDisplay(toplevel_w);
 	char *inst;
@@ -997,8 +955,7 @@ int nwant;
 
 /* explicitly handle pending X events when otherwise too busy */
 void
-XCheck (app)
-XtAppContext app;
+XCheck (XtAppContext app)
 {
         while ((XtAppPending (app) & XtIMXEvent) == XtIMXEvent)
 	    XtAppProcessEvent (app, XtIMXEvent);
@@ -1006,8 +963,7 @@ XtAppContext app;
 
 /* center the scrollbars in the given scrolled window */
 void
-centerScrollBars(sw_w)
-Widget sw_w;
+centerScrollBars(Widget sw_w)
 {
 	int min, max, slidersize, value;
 	XmScrollBarCallbackStruct sbcs;
@@ -1041,8 +997,7 @@ Widget sw_w;
  * full length of the current string.
  */
 void
-textColumns (w)
-Widget w;
+textColumns (Widget w)
 {
 	Arg args[10];
 	char *bp;
@@ -1069,10 +1024,7 @@ Widget w;
  * while we're at it, fix the text cursor.
  */
 void
-defaultTextFN (w, setcols,  x, y)
-Widget w;
-int setcols;
-char *x, *y;
+defaultTextFN (Widget w, int setcols,  char * x, char * y)
 {
 	char *tp = XmTextGetString (w);
 
@@ -1094,10 +1046,7 @@ char *x, *y;
 
 /* turn cursor on/off to follow focus */
 static void
-textFixCursorCB(w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+textFixCursorCB(Widget w, XtPointer client, XtPointer call)
 {
 	XmAnyCallbackStruct *ap = (XmAnyCallbackStruct *)call;
 	Arg a;
@@ -1110,8 +1059,7 @@ XtPointer call;
  * TextField
  */
 void
-fixTextCursor (w)
-Widget w;
+fixTextCursor (Widget w)
 {
 	Arg a;
 
@@ -1189,9 +1137,7 @@ setButtonInfo()
  * or like a label.
  */
 void
-buttonAsButton (w, whether)
-Widget w;
-int whether;
+buttonAsButton (Widget w, int whether)
 {
 	if (!look_like_inited) {
 	    setButtonInfo();
@@ -1293,10 +1239,7 @@ stopd_check()
 /* called when the user presses the Stop button */
 /* ARGSUSED */
 static void
-stopd_cb (w, client, call)
-Widget w;
-XtPointer client;
-XtPointer call;
+stopd_cb (Widget w, XtPointer client, XtPointer call)
 {
 	xe_msg (0, "User stop");
 	stopd_stopped = 1;

--- a/libip/explodegif.c
+++ b/libip/explodegif.c
@@ -78,10 +78,10 @@ static int EGApalette[16][3] = {
   {255,100,100}, {255,100,255}, {255,255,100}, {255,255,255} };
   
 
-static int   readImage();
+static int   readImage(PICINFO * pinfo);
 static int   ReadCode();
-static void  DoInterlace();
-static int   gifError();
+static void  DoInterlace(byte Index);
+static int   gifError(PICINFO * pinfo, char * st);
 
 static int   filesize;
 static int numcols;
@@ -92,16 +92,19 @@ static byte *dataptr;
 
 static char *g_errmsg;
 
-static int LoadGIF();
+static int LoadGIF(PICINFO * pinfo);
 
+/*
+@param char *raw;		 raw gif file 
+@param nraw;			 bytes ingif file 
+@param *wp, *hp;			 RETURN: image width/height 
+@param char *pixap[];		 RETURN: malloced w*h pixels, rgba indices 
+@param char ra[], ga[], ba[];	 RETURN: color map, 256 each 
+@param errmsg[];			 excuse, if return -1 
+*/
 int
-explodeGIF (raw, nraw, wp, hp, pixap, ra, ga, ba, errmsg)
-unsigned char *raw;		/* raw gif file */
-int nraw;			/* bytes ingif file */
-int *wp, *hp;			/* RETURN: image width/height */
-unsigned char *pixap[];		/* RETURN: malloced w*h pixels, rgba indices */
-unsigned char ra[], ga[], ba[];	/* RETURN: color map, 256 each */
-char errmsg[];			/* excuse, if return -1 */
+explodeGIF (unsigned char * raw, int nraw, int * wp, int * hp, unsigned char *pixap[],
+       unsigned char ra[], unsigned char ga[], unsigned char ba[], char errmsg[])
 {
 	PICINFO pi;
 
@@ -121,8 +124,7 @@ char errmsg[];			/* excuse, if return -1 */
 
 
 /*****************************/
-static int LoadGIF(pinfo)
-     PICINFO *pinfo;
+static int LoadGIF(PICINFO * pinfo)
 /*****************************/
 {
   /* returns '1' if successful */
@@ -386,8 +388,7 @@ static int LoadGIF(pinfo)
 
 
 /********************************************/
-static int readImage(pinfo)
-     PICINFO *pinfo;
+static int readImage(PICINFO * pinfo)
 {
   register byte ch, ch1, *ptr1, *picptr;
   int           i, npixels, maxpixels;
@@ -604,8 +605,7 @@ static int ReadCode()
 
 
 /***************************/
-static void DoInterlace(Index)
-     byte Index;
+static void DoInterlace(byte Index)
 {
   static byte *ptr = NULL;
   static int   oldYC = -1;
@@ -654,9 +654,7 @@ static void DoInterlace(Index)
 
       
 /*****************************/
-static int gifError(pinfo, st)
-     PICINFO *pinfo;
-     char    *st;
+static int gifError(PICINFO * pinfo, char * st)
 {
   strcpy (g_errmsg, st);
 

--- a/libip/fits.c
+++ b/libip/fits.c
@@ -46,11 +46,7 @@ static char simple[] = "SIMPLE  =                    T";
  * return 0 if ok, else put a short message into errmsg and return -1.
  */
 int
-writeFITS (fd, fip, errmsg, restore)
-int fd;
-FImage *fip;
-char *errmsg;
-int restore;
+writeFITS (int fd, FImage *fip, char *errmsg, int restore)
 {
 	int nbytes, n, nw;
 
@@ -144,10 +140,7 @@ writeFITSmem (FImage *fip, char **fts, char errmsg[], int restore)
  * return 0 if ok, else put a short message into errmsg and return -1.
  */
 int
-readFITS (fd, fip, errmsg)
-int fd;
-FImage *fip;
-char *errmsg;
+readFITS (int fd, FImage *fip, char *errmsg)
 {
 	int s;
 
@@ -286,10 +279,7 @@ readFITSmem (char *fits, int nfits, FImage *fip, char errmsg[])
  * N.B. read header portion first using readFITSHeader().
  */
 int
-readIncFITS (fd, fip, errmsg)
-int fd;
-FImage *fip;
-char *errmsg;
+readIncFITS (int fd, FImage *fip, char *errmsg)
 {
 #define	READCHUNK	4096
 
@@ -342,10 +332,7 @@ char *errmsg;
  * return 0 if ok, else put message into errmsg and return -1.
  */
 int
-readFITSHeader (fd, fip, errmsg)
-int fd;
-FImage *fip;
-char errmsg[];
+readFITSHeader (int fd, FImage *fip, char errmsg[])
 {
 	FITSRow row;
 	int nrows;
@@ -422,11 +409,7 @@ char errmsg[];
  * return 0 if ok else -1 if error.
  */
 int
-writeSimpleFITS (fd, pix, w, h, restore)
-int fd;
-char *pix;
-int w, h;
-int restore;
+writeSimpleFITS (int fd, char *pix, int w, int h, int restore)
 {
 	char errmsg[1024];
 	FImage fimage;
@@ -448,10 +431,7 @@ int restore;
  * we also require that if NAXISi, with i > 2, exist they be 1.
  */
 int
-getNAXIS (fip, n1p, n2p, errmsg)
-FImage *fip;
-int *n1p, *n2p;
-char errmsg[];
+getNAXIS (FImage * fip, int * n1p, int * n2p, char errmsg[])
 {
 	int n;
 	int i;
@@ -557,10 +537,7 @@ fmtFITSHeader (FImage *fip, char **mem, char *errmsg)
  * if trouble put message in errmsg and return -1, else return 0.
  */
 static int
-writeFITSHeader (fip, fd, errmsg)
-FImage *fip;
-int fd;
-char *errmsg;
+writeFITSHeader (FImage * fip, int fd, char *errmsg)
 {
 	char *hdr;
 	int nbytes, nw, n;
@@ -592,8 +569,7 @@ char *errmsg;
 /* initialize each field of a garbage fip to a default.
  */
 void
-initFImage (fip)
-FImage *fip;
+initFImage (FImage * fip)
 {
 	memset ((char *)fip, 0, sizeof(*fip));
 }
@@ -604,8 +580,7 @@ FImage *fip;
  *    pointer fields that are non-0; use initFImage for that.
  */
 void
-resetFImage (fip)
-FImage *fip;
+resetFImage (FImage *fip)
 {
 	if (fip->var)
 	    free ((char *)fip->var);
@@ -619,8 +594,7 @@ FImage *fip;
  * we assume fip->var is empty and we do not add END or pad.
  */
 void
-setSimpleFITSHeader (fip)
-FImage *fip;
+setSimpleFITSHeader (FImage * fip)
 {
 	setLogicalFITS (fip, "SIMPLE", 1, "Standard FITS");
 	setIntFITS (fip, "BITPIX", fip->bitpix, "Bits per pixel");
@@ -633,11 +607,7 @@ FImage *fip;
 
 /* add the Logical field v to fip->var */
 void
-setLogicalFITS (fip, name, v, comment)
-FImage *fip;
-char *name;
-int v;
-char *comment;
+setLogicalFITS (FImage * fip, char * name, int v, char * comment)
 {
 	char *rp;
 
@@ -652,11 +622,7 @@ char *comment;
 
 /* add (or replace) the Integer field v to fip->var */
 void
-setIntFITS (fip, name, v, comment)
-FImage *fip;
-char *name;
-int v;
-char *comment;
+setIntFITS (FImage * fip, char * name, int v, char * comment)
 {
 	char *rp;
 
@@ -671,12 +637,7 @@ char *comment;
 
 /* add (or replace) the Real field v with so many significant digits */
 void
-setRealFITS (fip, name, v, sigdig, comment)
-FImage *fip;
-char *name;
-double v;
-int sigdig;
-char *comment;
+setRealFITS (FImage * fip, char * name, double v, int sigdig, char * comment)
 {
 	char *rp;
 
@@ -694,11 +655,7 @@ char *comment;
  *   col 20, i.e. 8 characters minimum including blanks.
  */
 void
-setStringFITS (fip, name, string, comment)
-FImage *fip;
-char *name;
-char *string;
-char *comment;
+setStringFITS (FImage * fip, char * name, char * string, char * comment)
 {
 	char *rp;
 
@@ -716,10 +673,7 @@ char *comment;
  * this is generally only used for names of HISTORY and COMMENT
  */
 void
-setCommentFITS (fip, name, comment)
-FImage *fip;
-char *name;
-char *comment;
+setCommentFITS (FImage * fip, char * name, char * comment)
 {
 	char lline[FITS_HCOLS+1];	/* room for sprintf's trailing '\0' */
 	int l = strlen(comment);
@@ -741,10 +695,7 @@ char *comment;
  * return 0 and set *vp if we find it, else return -1.
  */
 int
-getLogicalFITS (fip, name, vp)
-FImage *fip;
-char *name;
-int *vp;
+getLogicalFITS (FImage * fip, char * name, int * vp)
 {
 	char *rp;
 
@@ -762,10 +713,7 @@ int *vp;
  * return 0 and set *vp if we find it, else return -1.
  */
 int
-getIntFITS (fip, name, vp)
-FImage *fip;
-char *name;
-int *vp;
+getIntFITS (FImage * fip, char * name, int * vp)
 {
 	char *rp;
 
@@ -779,10 +727,7 @@ int *vp;
  * return 0 and set *vp if we find it, else return -1.
  */
 int
-getRealFITS (fip, name, vp)
-FImage *fip;
-char *name;
-double *vp;
+getRealFITS (FImage * fip, char * name, double *vp)
 {
 	char buf[32];
 	char *dp, *rp;
@@ -803,10 +748,7 @@ double *vp;
  * buf should be at least 73 chars long.
  */
 int
-getCommentFITS (fip, name, buf)
-FImage *fip;
-char *name;
-char *buf;
+getCommentFITS (FImage * fip, char * name, char * buf)
 {
 	char *rp;
 
@@ -823,10 +765,7 @@ char *buf;
  * string should be at least 69 chars long.
  */
 int
-getStringFITS (fip, name, string)
-FImage *fip;
-char *name;
-char *string;
+getStringFITS (FImage * fip, char * name, char * string)
 {
 	char *string0 = string;
 	char *rp;
@@ -855,10 +794,7 @@ char *string;
  * if find it set *rpp to its address and return 0, else -1.
  */
 static int
-findFImageVar (fip, name, rpp)
-FImage *fip;
-char *name;
-char **rpp;
+findFImageVar (FImage * fip, char * name, char **rpp)
 {
 	char field[9];	/* FITS field name */
 	int i;
@@ -876,9 +812,7 @@ char **rpp;
 /* add the row to the end of the fip->var array.
  */
 void
-addFImageVar (fip, row)
-FImage *fip;
-FITSRow row;
+addFImageVar (FImage * fip, FITSRow row)
 {
 	char *mem;
 	int newn;
@@ -906,9 +840,7 @@ FITSRow row;
  * return 0 if ok, else -1 if field didn't exist.
  */
 int
-delFImageVar (fip, name)
-FImage *fip;
-char *name;
+delFImageVar (FImage * fip, char *name)
 {
 	char *rp;
 	char *mem;
@@ -947,9 +879,7 @@ char *name;
  * return 0 if ok, else -1 if trouble.
  */
 int
-cpyFImageVar (fip1, fip2, name)
-FImage *fip1, *fip2;
-char *name;
+cpyFImageVar (FImage * fip1, FImage * fip2, char * name)
 {
 	char *srcrow, *dstrow;
 
@@ -966,11 +896,7 @@ char *name;
  * as a F or T in column 30.
  */
 static void
-fmtLogicalFITS (line, name, value, comment)
-FITSRow line;
-char *name;
-int value;
-char *comment;
+fmtLogicalFITS (FITSRow line, char * name, int value, char * comment)
 {
 	sprintf (line, "%-8.8s=%20s%c", name, "", value ? 'T' : 'F');
 	fmtInlineComment (line, comment);
@@ -980,11 +906,7 @@ char *comment;
  * right justified in columns 11-30.
  */
 static void
-fmtIntFITS (line, name, value, comment)
-FITSRow line;
-char *name;
-int value;
-char *comment;
+fmtIntFITS (FITSRow line, char * name, int value, char * comment)
 {
 	char str[30];
 	int strl;
@@ -1000,12 +922,7 @@ char *comment;
  * in columns 11-30 with at most sigdig significant digits.
  */
 static void
-fmtRealFITS (line, name, value, sigdig, comment)
-FITSRow line;
-char *name;
-double value;
-int sigdig;
-char *comment;
+fmtRealFITS (FITSRow line, char * name, double value, int sigdig, char * comment)
 {
 	sprintf (line, "%-8.8s= %20.*G", name, sigdig, value);
 	fmtInlineComment (line, comment);
@@ -1016,11 +933,7 @@ char *comment;
  * characters minimum including blanks.
  */
 static void
-fmtStringFITS (line, name, value, comment)
-FITSRow line;
-char *name;
-char *value;
-char *comment;
+fmtStringFITS (FITSRow line, char * name, char * value, char * comment)
 {
 	char lline[FITS_HCOLS+1];	/* room for sprintf's trailing '\0' */
 	int l = strlen(value);
@@ -1044,8 +957,7 @@ char *comment;
 
 /* write the END marker to the FITS line */
 static void
-fmtENDFITS (line)
-FITSRow line;
+fmtENDFITS (FITSRow line)
 {
 	sprintf (line, "%-79s", "END");
 	line[79] = ' ';
@@ -1053,9 +965,7 @@ FITSRow line;
 
 /* attend to the final 50 chars of line */
 static void
-fmtInlineComment (line, comment)
-FITSRow line;
-char *comment;
+fmtInlineComment (FITSRow line, char * comment)
 {
 	char buf[100]; /* buffer to allow for sprintf's trailing '\0' */
 
@@ -1069,8 +979,7 @@ char *comment;
 /* turn native unsigned shorts into FITS' big-endian signed.
  */
 static void
-enFITSPixels (fip)
-FImage *fip;
+enFITSPixels (FImage * fip)
 {
 	unsigned short *pixp = (unsigned short *)fip->image;
 	int n = fip->sh * fip->sw;
@@ -1098,8 +1007,7 @@ FImage *fip;
 /* turn FITS' big-endian signed shorts into native unsigned shorts.
  */
 static void
-unFITSPixels (fip)
-FImage *fip;
+unFITSPixels (FImage * fip)
 {
 	unsigned short *pixp = (unsigned short *)fip->image;
 	int n = fip->sh * fip->sw;

--- a/libip/fsmatch.c
+++ b/libip/fsmatch.c
@@ -63,7 +63,7 @@ static int newTri (Tri *tp, double mina, Vtx *v0, Vtx *v1, Vtx *v2);
 static void initFITS (FImage *initial, FImage *test);
 static void prWCS (char *label, FImage *fip);
 static int lsFit (FImage *fip);
-static double chisqr(double p[]);
+static double chisqr(double p[4]);
 static int discardOutlyers(FImage *fip);
 static int pv_qscmpf (const void *v1, const void *v2);
 static void setTrLevel(void);

--- a/libip/lstsqr.c
+++ b/libip/lstsqr.c
@@ -12,7 +12,7 @@
 
 /* from Numerical Recipes */
 static int amoeba(double **p, double *y, int ndim, double ftol,
-    double (*funk)(), int *nfunk);
+    double (*funk)(double p[]), int *nfunk);
 
 /* this lets us map 1-based arrays into 0-based arrays */
 static double (*chisqr_0based)(double p[]);
@@ -92,7 +92,7 @@ double ftol)			/* desired fractional tolerance */
 /* following are from Numerical Recipes in C */
 
 static double amotry(double **p, double *y, double *psum, int ndim,
-    double (*funk)(), int ihi, int *nfunk, double fac);
+    double (*funk)(double p[]), int ihi, int *nfunk, double fac);
 static void nrerror( char error_text[]);
 static double *vector(int nl, int nh);
 static void free_vector(double *v, int nl, int nh);
@@ -108,12 +108,10 @@ static void free_vector(double *v, int nl, int nh);
 						sum += p[i][j]; psum[j]=sum;}
 
 static int
-amoeba(p,y,ndim,ftol,funk,nfunk)
-double **p,y[],ftol,(*funk)();
-int ndim,*nfunk;
+amoeba(double **p,double y[],int ndim,double ftol,double (*funk)(double p[]),int * nfunk)
 {
 	int i,j,ilo,ihi,inhi,mpts=ndim+1;
-	double ytry,ysave,sum,rtol,amotry(),*psum,*vector();
+	double ytry,ysave,sum,rtol,*psum,*vector();
 	void nrerror(),free_vector();
 	double yihilo;
 
@@ -168,9 +166,7 @@ int ndim,*nfunk;
 }
 
 static double
-amotry(p,y,psum,ndim,funk,ihi,nfunk,fac)
-double **p,*y,*psum,(*funk)(),fac;
-int ndim,ihi,*nfunk;
+amotry(double **p,double *y,double *psum,int ndim, double (*funk)(double p[]),int ihi,int * nfunk,double fac)
 {
 	int j;
 	double fac1,fac2,ytry,*ptry,*vector();
@@ -202,8 +198,7 @@ int ndim,ihi,*nfunk;
 /* nrutil.c */
 
 static void
-nrerror(error_text)
-char error_text[];
+nrerror(char error_text[])
 {
 	fprintf(stderr,"Numerical Recipes run-time error...\n");
 	fprintf(stderr,"%s\n",error_text);
@@ -214,8 +209,7 @@ char error_text[];
 
 
 static double *
-vector(nl,nh)
-int nl,nh;
+vector(int nl,int nh)
 {
 	double *v;
 
@@ -226,9 +220,7 @@ int nl,nh;
 
 
 static void
-free_vector(v,nl,nh)
-double *v;
-int nl,nh;
+free_vector(double * v,int nl,int nh)
 {
 	free((char*) (v+nl));
 }

--- a/libip/wcs.c
+++ b/libip/wcs.c
@@ -29,10 +29,7 @@ static int setWCScache (FImage *fip);
  * return 0 if all ok, else -1.
  */
 int
-xy2RADec (fip, x, y, rap, decp)
-FImage *fip;
-double x, y;
-double *rap, *decp;
+xy2RADec (FImage * fip, double x, double y, double * rap, double * decp)
 {
 	double xpos;		/* x (RA) coordinate (deg) */
 	double ypos;		/* y (dec) coordinate (deg) */
@@ -57,10 +54,7 @@ double *rap, *decp;
  * return 0 if all ok, else -1.
  */
 int
-RADec2xy (fip, ra, dec, xp, yp)
-FImage *fip;
-double ra, dec;
-double *xp, *yp;
+RADec2xy (FImage * fip, double ra, double dec, double * xp, double * yp)
 {
 	double xpos;		/* x (RA) coordinate (deg) */
 	double ypos;		/* y (dec) coordinate (deg) */
@@ -86,8 +80,7 @@ double *xp, *yp;
  * return 0 if ok, else return -1.
  */
 static int
-dsswcs (fip)
-FImage *fip;
+dsswcs (FImage * fip)
 {
 	double a0, d0, a1, d1;
 	double px, py;
@@ -144,10 +137,7 @@ FImage *fip;
  * return 0 if ok, else -1.
  */
 static int
-dssxy2RADec (fip, X, Y, rap, decp)
-FImage *fip;
-double X, Y;
-double *rap, *decp;
+dssxy2RADec (FImage * fip, double X, double Y, double * rap, double * decp)
 {
 	char buf[128];
 	double cnpix1, cnpix2;
@@ -230,8 +220,7 @@ double *rap, *decp;
  * return 0 if ok, else -1
  */
 static int
-setWCScache (fip)
-FImage *fip;
+setWCScache (FImage * fip)
 {
 	FITSRow typestr;
 	double tmp;
@@ -262,7 +251,7 @@ FImage *fip;
 	return (0);
 }
 
-
+
 /*  worldpos.c -- WCS Algorithms from Classic AIPS.
     Copyright (C) 1994
     Associated Universities, Inc. Washington DC, USA.
@@ -339,20 +328,8 @@ FImage *fip;
        and addition of a 360d difference test to MER case of worldpos(). 
 */
 
-static int worldpos(xpix, ypix, xref, yref, xrefpix, yrefpix, xinc, yinc, rot,
-							      type, xpos, ypos)
-double xpix;
-double ypix;
-double xref;
-double yref;
-double xrefpix;
-double yrefpix;
-double xinc;
-double yinc;
-double rot;
-char *type;
-double *xpos;
-double *ypos;
+static int worldpos(double xpix, double ypix, double xref, double yref, double xrefpix, double yrefpix, double xinc, double yinc, double rot,
+                                                             char * type, double * xpos, double * ypos)
 /*-----------------------------------------------------------------------*/
 /* routine to determine accurate position for pixel coordinates          */
 /* returns 0 if successful otherwise:                                    */
@@ -548,20 +525,8 @@ double *ypos;
   return 0;
 }  /* End of worldpos */
 
-static int xypix(xpos, ypos, xref, yref, xrefpix, yrefpix, xinc, yinc, rot,
-							      type, xpix, ypix)
-double xpos;
-double ypos;
-double xref;
-double yref; 
-double xrefpix;
-double yrefpix;
-double xinc;
-double yinc;
-double rot;
-char *type;
-double *xpix;
-double *ypix;
+static int xypix( double xpos, double ypos, double xref, double yref, double xrefpix, double yrefpix, double xinc, double yinc, double rot,
+                                                             char * type, double *xpix, double *ypix)
 /*-----------------------------------------------------------------------*/
 /* routine to determine accurate pixel coordinates for an RA and Dec     */
 /* returns 0 if successful otherwise:                                    */


### PR DESCRIPTION
This replaces the obsolete K&R style of function declarations
by the ANSI-C equivalent declarations.
This means to close https://github.com/XEphem/XEphem/discussions/104 
and to allow compilation for equivalent newer compilers without the need
to downgrade C-compabitility levels.
