### PR TITLE
Fix type mismatch for .* printf specifier

### DIFF
--- a/GUI/xephem/webdbmenu.c
+++ b/GUI/xephem/webdbmenu.c
@@ -488,7 +488,7 @@ char *url;
 	    slash = strrchr (url+ltransport, '/');
 	    dot = strrchr (url, '.');
 	    if (dot < slash) {
-	        snprintf (filename, 255, "%s/%.*s.edb", getPrivateDir(), strlen(url)-(int)(slash-url)-1, slash+1);
+	        snprintf (filename, 255, "%s/%.*s.edb", getPrivateDir(), (int)strlen(url)-(int)(slash-url)-1, slash+1);
 	    } else {
 	        snprintf (filename, 255, "%s/%.*s.edb", getPrivateDir(), (int)(dot-slash)-1, slash+1);
 	    }


### PR DESCRIPTION
The whole expression needs to be of type int, but (accidently?) was size_t. These types do not have the same size on all architectures, which may cause printf to access stack garbage.