### PR TITLE
Properly cast char args to ctype functions to unsigned

### DIFF
--- a/GUI/xephem/compiler.c
+++ b/GUI/xephem/compiler.c
@@ -212,7 +212,7 @@ next_token ()
 	int tok = ERR;	/* just something illegal */
 	char c;
 
-	while (isspace(c = *cexpr))
+	while (isspace((unsigned char)(c = *cexpr)))
 	    cexpr++;
 	lcexpr = cexpr++;
 

--- a/GUI/xephem/gallerymenu.c
+++ b/GUI/xephem/gallerymenu.c
@@ -661,7 +661,7 @@ trimws (char *s)
 {
 	char *s0;
 
-	while (isspace(*s))
+	while (isspace((unsigned char)*s))
 	    s++;
 	s0 = s;
 
@@ -670,7 +670,7 @@ trimws (char *s)
 
 	do
 	    *s-- = '\0';
-	while (s >= s0 && isspace(*s));
+	while (s >= s0 && isspace((unsigned char)*s));
 
 	return (s0);
 }

--- a/GUI/xephem/indimenu.c
+++ b/GUI/xephem/indimenu.c
@@ -2520,7 +2520,7 @@ handleOneBLOB (XMLEle *root, IBLOB *bp, char errmsg[])
 
 	/* rig up a file name from the timestamp and format */
 	for (i = 0, tsp = bvp->timestamp; *tsp != '\0'; tsp++)
-	    if (isdigit(*tsp))
+	    if (isdigit((unsigned char)*tsp))
 		fn[i++] = *tsp;
 	fn[i] = '\0';
 	strcat (fn, bp->format);

--- a/GUI/xephem/mainmenu.c
+++ b/GUI/xephem/mainmenu.c
@@ -2241,7 +2241,7 @@ Field *fp;
 		    char *txt0, *txt;
 
 		    get_xmstring (fp->pb_w, XmNlabelString, &txt0);
-		    for (txt = txt0; *txt && !isdigit(*txt); txt++)
+		    for (txt = txt0; *txt && !isdigit((unsigned char)*txt); txt++)
 			continue;
 		    set_xmstring (prompt_w, XmNtextString, txt);
 		    XtFree (txt0);

--- a/GUI/xephem/marsmenu.c
+++ b/GUI/xephem/marsmenu.c
@@ -998,7 +998,7 @@ m_create_mfform()
 		int j;
 
 		/* widget name is first word in type */
-		for (j = 0; isalpha(mfsp->type[j]); j++)
+		for (j = 0; isalpha((unsigned char)mfsp->type[j]); j++)
 		    buf[j] = mfsp->type[j];
 		buf[j] = '\0';
 
@@ -2222,7 +2222,7 @@ char *name;
 {
 	int l;
 
-	for (l = strlen(name)-1; l >= 0 && isspace(name[l]); --l)
+	for (l = strlen(name)-1; l >= 0 && isspace((unsigned char)name[l]); --l)
 	    name[l] = '\0';
 }
 

--- a/GUI/xephem/saveres.c
+++ b/GUI/xephem/saveres.c
@@ -1785,10 +1785,10 @@ char *from;
 {
 	char *lastnwsp;		/* last non w/s char in to not counting '\0' */
 
-	while (isspace(*from))
+	while (isspace((unsigned char)*from))
 	    from++;
 	for (lastnwsp = NULL; (*to = *from) != '\0'; to++, from++)
-	    if (!isspace(*to))
+	    if (!isspace((unsigned char)*to))
 		lastnwsp = to;
 	if (lastnwsp)
 	    *++lastnwsp = '\0';

--- a/GUI/xephem/sites.c
+++ b/GUI/xephem/sites.c
@@ -183,9 +183,9 @@ int maxn;
 	 * n is an index, not a count.
 	 */
 	for (n = fl-1; n >= maxn-4; ) {
-	    while (n > 0 && isalnum(full[n]))
+	    while (n > 0 && isalnum((unsigned char)full[n]))
 		n--;
-	    while (n > 0 && (ispunct(full[n]) || isspace(full[n])))
+	    while (n > 0 && (ispunct((unsigned char)full[n]) || isspace((unsigned char)full[n])))
 		n--;
 	}
 	(void) sprintf (ab, "%.*s...", n+1, full);
@@ -654,7 +654,7 @@ read_file (FILE *fp)
 
 	    /* strip trailing blanks off name */
 	    for (l = strlen (name); --l >= 0; )
-		if (isspace(name[l]))
+		if (isspace((unsigned char)name[l]))
 		    name[l] = '\0';
 		else
 		    break;

--- a/GUI/xephem/skyip.c
+++ b/GUI/xephem/skyip.c
@@ -2573,8 +2573,8 @@ char msg[];
 
 	/* relax need for user to type in upper case */
 	for (bp = kw; *bp; bp++)
-	    if (islower(*bp))
-		*bp = toupper(*bp);
+	    if (islower((unsigned char)*bp))
+		*bp = toupper((unsigned char)*bp);
 
 	/* get from FITS header and copy to our value field */
 	if (getStringFITS (&fim, kw, valu) == 0) {

--- a/GUI/xephem/skyviewmenu.c
+++ b/GUI/xephem/skyviewmenu.c
@@ -9721,7 +9721,7 @@ int d;		/* diam of object we are labeling, pixels */
 	    if (sv_ggc && chk_greeklabel (name, &gl, &g)) {
 		XTextExtents (sv_gf, &g, 1, &dir, &asc, &des, &xcs);
 		gw = xcs.width;
-		if (isdigit(name[4+gl])) {
+		if (isdigit((unsigned char)name[4+gl])) {
 		    /* don't crowd the superscript */
 		    XTextExtents (sv_pf, name+gl+4, 1, &dir, &asc, &des, &xcs);
 		    gw += 1;
@@ -9820,7 +9820,7 @@ char *gcodep;	/* code to use for drawing the greek character */
 
 	/* find length of potentionally greek portion */
 	for (gl = 0; ; gl++)
-	    if (!isalpha(name[4+gl]))
+	    if (!isalpha((unsigned char)name[4+gl]))
 		break;
 	if (gl < 2)	/* shortest greek name is 2 chars */
 	    return (0);

--- a/GUI/xephem/xmisc.c
+++ b/GUI/xephem/xmisc.c
@@ -1130,7 +1130,7 @@ strtolower (char *str)
 
 	/* actually faster to /not/ call isupper() first */
 	do
-	    *s = tolower (*s);
+	    *s = tolower ((unsigned char)*s);
 	while (*s++);
 
 	return (str);

--- a/libastro/constel.c
+++ b/libastro/constel.c
@@ -1665,9 +1665,9 @@ cns_loadfigs (FILE *fp, char *msg)
 	    int code;
 
 	    /* skip leading/trailing whitespace, blank lines and # lines */
-	    for (lp = line+strlen(line)-1; lp>=line && isspace(*lp); --lp)
+	    for (lp = line+strlen(line)-1; lp>=line && isspace((unsigned char)*lp); --lp)
 		*lp = '\0';
-	    for (lp = line; isspace(*lp); lp++)
+	    for (lp = line; isspace((unsigned char)*lp); lp++)
 		continue;
 	    if (*lp == '#' || *lp == '\0')
 		continue;

--- a/libastro/dbfmt.c
+++ b/libastro/dbfmt.c
@@ -196,11 +196,11 @@ db_tle (char *name, char *l1, char *l2, Obj *op)
 	/* check for correct line numbers, macthing satellite numbers and
 	 * correct checksums.
 	 */
-	while (isspace(*l1))
+	while (isspace((unsigned char)*l1))
 	    l1++;
 	if (*l1 != '1')
 	    return (-1);
-	while (isspace(*l2))
+	while (isspace((unsigned char)*l2))
 	    l2++;
 	if (*l2 != '2')
 	    return (-1);
@@ -218,7 +218,7 @@ db_tle (char *name, char *l1, char *l2, Obj *op)
 	op->o_type = EARTHSAT;
 
 	/* name, sans leading and trailing whitespace */
-	while (isspace(*name))
+	while (isspace((unsigned char)*name))
 	    name++;
 	i = strcspn (name, "\r\n");
 	while (i > 0 && name[i-1] == ' ')
@@ -331,7 +331,7 @@ dbline_candidate (char *buf)
 {
 	char c = buf[0];
 
-	return (c == '#' || c == '!' || isspace(c) ? -1 : 0);
+	return (c == '#' || c == '!' || isspace((unsigned char)c) ? -1 : 0);
 }
 
 /* return 0 if TLE checksum is ok, else -1 */
@@ -345,7 +345,7 @@ tle_sum (char *l)
 	    char c = *l++;
 	    if (c == '\0')
 		return (-1);
-	    if (isdigit(c))
+	    if (isdigit((unsigned char)c))
 		sum += c - '0';
 	    else if (c == '-')
 		sum++;
@@ -492,11 +492,11 @@ crack_e (Obj *op, char *flds[MAXFLDS], int nf, char whynot[])
 
 	/* magnitude model gk or HG(default). allow prefixes in either field */
 	op->e_mag.whichm = flds[11][0] == 'g' ? MAG_gk : MAG_HG;
-	if (isdigit(flds[11][0]))
+	if (isdigit((unsigned char)flds[11][0]))
 	    op->e_mag.m1 = (float) atod(&flds[11][0]);
 	else
 	    op->e_mag.m1 = (float) atod(&flds[11][1]);
-	if (isdigit(flds[12][0]))
+	if (isdigit((unsigned char)flds[12][0]))
 	    op->e_mag.m2 = (float) atod(&flds[12][0]);
 	else
 	    op->e_mag.m2 = (float) atod(&flds[12][1]);
@@ -741,7 +741,7 @@ crack_B (Obj *op, char *flds[MAXFLDS], int nf, char whynot[])
 		op->b_bo.bo_P /= 365.25;
 		break;
 	    default:
-		if (c != ' ' && !isdigit(c)) {
+		if (c != ' ' && !isdigit((unsigned char)c)) {
 		    if (whynot)
 			sprintf (whynot,"%s: B period suffix not Y, D or H: %c",
 								enm(flds), c);

--- a/liblilxml/base64.c
+++ b/liblilxml/base64.c
@@ -108,7 +108,7 @@ from64tobits(char *out, const char *in)
                 ++len;
             }
         }
-	while (isspace(*in))
+	while (isspace((unsigned char)*in))
 	    in++;
     } while (*in && digit4 != '=');
 


### PR DESCRIPTION
The <ctype.h> functions only work on int values in the range of unsigned characters. Passing signed char values without cast may cause undefined behaviour on architectures where the default char type is signed.